### PR TITLE
Improve MidiFile.play to avoid time drift.

### DIFF
--- a/docs/midi_files.rst
+++ b/docs/midi_files.rst
@@ -49,7 +49,8 @@ you can do::
     if msg.is_meta:
         ...
 
-This makes it easy to play back a MIDI file on a port::
+This makes it easy to play back a MIDI file on a port (though this simple
+implementation is subject to time drift)::
 
     for msg in MidiFile('song.mid'):
         time.sleep(msg.time)
@@ -61,8 +62,8 @@ This is so useful that there's a method for it::
     for msg in MidiFile('song.mid').play():
         port.send(msg)
 
-This does the sleeping and filtering for you. If you pass
-``meta_messages=True`` you will also get meta messages. These can not
+This does the sleeping and filtering for you (while avoiding drift). If you
+pass ``meta_messages=True`` you will also get meta messages. These can not
 be sent on ports, which is why they are off by default.
 
 

--- a/examples/midifiles/create_midi_file.py
+++ b/examples/midifiles/create_midi_file.py
@@ -4,8 +4,10 @@ Create a new MIDI file with some random notes.
 
 The file is saved to test.mid.
 """
+from __future__ import division
 import random
-from mido import Message, MidiFile, MidiTrack
+import sys
+from mido import Message, MidiFile, MidiTrack, MAX_PITCHWHEEL
 
 notes = [64, 64+7, 64+12]
 
@@ -16,10 +18,14 @@ outfile.tracks.append(track)
 
 track.append(Message('program_change', program=12))
 
-delta = 16
+delta = 300
+ticks_per_expr = int(sys.argv[1]) if len(sys.argv) > 1 else 20
 for i in range(4):
     note = random.choice(notes)
     track.append(Message('note_on', note=note, velocity=100, time=delta))
-    track.append(Message('note_off', note=note, velocity=100, time=delta))
+    for j in range(delta // ticks_per_expr):
+        pitch = MAX_PITCHWHEEL * j * ticks_per_expr // delta
+        track.append(Message('pitchwheel', pitch=pitch, time=ticks_per_expr))
+    track.append(Message('note_off', note=note, velocity=100, time=0))
 
 outfile.save('test.mid')

--- a/examples/midifiles/play_midi_file.py
+++ b/examples/midifiles/play_midi_file.py
@@ -8,6 +8,7 @@ Run with (for example):
 """
 import sys
 import mido
+import time
 from mido import MidiFile
 
 filename = sys.argv[1]
@@ -18,9 +19,13 @@ else:
 
 with mido.open_output(portname) as output:
     try:
-        for message in MidiFile(filename).play():
+        midifile = MidiFile(filename)
+        t0 = time.time()
+        for message in midifile.play():
             print(message)
             output.send(message)
+        print('play time: {:.2f} s (expected {:.2f})'.format(
+                time.time() - t0, midifile.length))
 
     except KeyboardInterrupt:
         print()

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -402,9 +402,15 @@ class MidiFile(object):
 
         """
         sleep = time.sleep
+        now = time.time
+        t0 = now()
+        file_time = 0
 
         for msg in self:
-            sleep(msg.time)
+            file_time += msg.time
+            duration_to_next_event = file_time - (now() - t0)
+            if (duration_to_next_event > 0):
+                sleep(duration_to_next_event)
 
             if isinstance(msg, MetaMessage) and not meta_messages:
                 continue


### PR DESCRIPTION
Addresses #160

Also modify midifile examples to include fine-grained events
and report time drift.