### PR TITLE
eval-able repr() for Message, MidiTrack, MidiFile

### DIFF
--- a/mido/frozen.py
+++ b/mido/frozen.py
@@ -3,9 +3,14 @@ from .midifiles import MetaMessage, UnknownMetaMessage
 
 
 class Frozen(object):
-    def __repr__(self):
-        text = super(Frozen, self).__repr__()
+    def __str__(self):
+        text = super(Frozen, self).__str__()
         return '<frozen {}'.format(text[1:])
+
+    def __repr__(self):
+        # canonicalize to mutable objects
+        r = super(Frozen, self).__repr__()
+        return r[len('Frozen'):]
 
     def __setattr__(self, *_):
         raise ValueError('frozen message is immutable')

--- a/mido/messages/messages.py
+++ b/mido/messages/messages.py
@@ -54,6 +54,15 @@ class BaseMessage(object):
         """
         return cl(**data)
 
+    def __repr__(self):
+        d = self.dict()
+        msg_type = d.pop('type')
+        items = getattr(d, 'iteritems', d.items)
+        return "%s('%s', %s)" % (
+            type(self).__name__,
+            msg_type,
+            ', '.join('%s=%s' % item for item in items()))
+
     @property
     def is_realtime(self):
         """True if the message is a system realtime message."""
@@ -161,9 +170,6 @@ class Message(BaseMessage):
 
     def __str__(self):
         return msg2str(vars(self))
-
-    def __repr__(self):
-        return '<message {}>'.format(str(self))
 
     def _setattr(self, name, value):
         if name == 'type':

--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -535,7 +535,7 @@ class MetaMessage(BaseMessage):
                 encode_variable_int(len(data)) +
                 data)
 
-    def __repr__(self):
+    def __str__(self):
         spec = _META_SPEC_BY_TYPE[self.type]
         attributes = []
         for name in spec.attributes:
@@ -561,13 +561,18 @@ class UnknownMetaMessage(MetaMessage):
             'data': data,
             'time': time})
 
-    def __repr__(self):
+    def __str__(self):
         return ('<unknown meta message'
                 ' type_byte=0x{:02x} '
                 'data={!r} time={}>').format(self.type_byte,
                                              self.data,
                                              self.time
                                              )
+
+    def __repr__(self):
+        # fix message type artifact
+        r = super(UnknownMetaMessage, self).__repr__()
+        return r.replace("'unknown_meta', ", '')
 
     def __setattr__(self, name, value):
         # This doesn't do any checking.

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -293,7 +293,8 @@ class MidiFile(object):
                  type=1, ticks_per_beat=DEFAULT_TICKS_PER_BEAT,
                  charset='latin1',
                  debug=False,
-                 clip=False
+                 clip=False,
+                 tracks=None
                  ):
 
         self.filename = filename
@@ -309,7 +310,9 @@ class MidiFile(object):
             raise ValueError(
                 'invalid format {} (must be 0, 1 or 2)'.format(format))
 
-        if file is not None:
+        if tracks is not None:
+            self.tracks = tracks
+        elif file is not None:
             self._load(file)
         elif self.filename is not None:
             with io.open(filename, 'rb') as file:
@@ -461,10 +464,17 @@ class MidiFile(object):
                 else:
                     print('{!r}'.format(msg))
 
-    def __repr__(self):
+    def __str__(self):
         return '<midi file {!r} type {}, {} tracks, {} messages>'.format(
             self.filename, self.type, len(self.tracks),
             sum([len(track) for track in self.tracks]))
+
+    def __repr__(self):
+        tracks_str = ',\n'.join(repr(track) for track in self.tracks)
+        tracks_str = '\n'.join('  ' + line for line in tracks_str.splitlines())
+        tracks_str = (', tracks=[\n%s\n]' % tracks_str) if self.tracks else ''
+        return 'MidiFile(type=%s, ticks_per_beat=%s%s)' % (
+            self.type, self.ticks_per_beat, tracks_str)
 
     # The context manager has no purpose but is kept around since it was
     # used in examples in the past.

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -50,8 +50,15 @@ class MidiTrack(list):
     def __mul__(self, other):
         return self.__class__(list.__mul__(self, other))
 
-    def __repr__(self):
+    def __str__(self):
         return '<midi track {!r} {} messages>'.format(self.name, len(self))
+
+    def __repr__(self):
+        messages = ''
+        if len(self) > 0:
+            template = '[\n  %s]' if len(self) > 1 else '[%s]'
+            messages = template % ',\n  '.join(repr(m) for m in self)
+        return 'MidiTrack(%s)' % messages
 
 
 def _to_abstime(messages):

--- a/tests/messages/test_messages.py
+++ b/tests/messages/test_messages.py
@@ -108,3 +108,9 @@ def test_dict_sysex_data():
 def test_from_hex_sysex_data_type():
     msg = Message.from_hex('F0 01 02 03 F7')
     assert isinstance(msg.data, SysexData)
+
+
+def test_repr():
+    msg = Message('note_on', channel=1, note=2, time=3)
+    msg_eval = eval(repr(msg))
+    assert msg == msg_eval

--- a/tests/midifiles/test_meta.py
+++ b/tests/midifiles/test_meta.py
@@ -1,5 +1,5 @@
 import pytest
-from mido.midifiles.meta import MetaMessage, MetaSpec_key_signature, KeySignatureError
+from mido.midifiles.meta import MetaMessage, UnknownMetaMessage, MetaSpec_key_signature, KeySignatureError
 
 
 def test_copy_invalid_argument():
@@ -30,3 +30,13 @@ class TestKeySignature:
         msg = MetaMessage('key_signature')
         MetaSpec_key_signature().decode(msg, input_bytes)
         assert msg.key == expect_sig
+
+def test_meta_message_repr():
+    msg = MetaMessage('end_of_track', time=10)
+    msg_eval = eval(repr(msg))
+    assert msg == msg_eval
+
+def test_unknown_meta_message_repr():
+    msg = UnknownMetaMessage(type_byte=99, data=[1, 2], time=10)
+    msg_eval = eval(repr(msg))
+    assert msg == msg_eval

--- a/tests/midifiles/test_midifiles.py
+++ b/tests/midifiles/test_midifiles.py
@@ -1,7 +1,7 @@
 import io
 from pytest import raises
 from mido.messages import Message
-from mido.midifiles.midifiles import MidiFile
+from mido.midifiles.midifiles import MidiFile, MidiTrack
 from mido.midifiles.meta import MetaMessage, KeySignatureError
 
 HEADER_ONE_TRACK = """
@@ -163,3 +163,19 @@ def test_meta_messages_with_length_0():
 
         MetaMessage('end_of_track'),
     ]
+
+
+def test_midifile_repr():
+    midifile = MidiFile(type=1, ticks_per_beat=123, tracks=[
+        MidiTrack([
+            Message('note_on', channel=1, note=2, time=3),
+            Message('note_off', channel=1, note=2, time=3)]),
+        MidiTrack([
+            MetaMessage('sequence_number', number=5),
+            Message('note_on', channel=2, note=6, time=9),
+            Message('note_off', channel=2, note=6, time=9)]),
+    ])
+    midifile_eval = eval(repr(midifile))
+    for track, track_eval in zip(midifile.tracks, midifile_eval.tracks):
+        for m1, m2 in zip(track, track_eval):
+            assert m1 == m2

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -1,5 +1,9 @@
+import itertools
+from mido.messages import Message
 from mido.midifiles.meta import MetaMessage
 from mido.midifiles.tracks import MidiTrack
+
+zip = getattr(itertools, 'izip', zip)
 
 
 def test_track_slice():
@@ -16,3 +20,13 @@ def test_track_name():
     # The track should use the first name it finds.
     track = MidiTrack([name1, name2])
     assert track.name == name1.name
+
+
+def test_track_repr():
+    track = MidiTrack([
+        Message('note_on', channel=1, note=2, time=3),
+        Message('note_off', channel=1, note=2, time=3),
+    ])
+    track_eval = eval(repr(track))
+    for m1, m2 in zip(track, track_eval):
+        assert m1 == m2

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -1,4 +1,5 @@
 from mido.messages import Message
+from mido.midifiles.meta import MetaMessage, UnknownMetaMessage
 from mido.frozen import (is_frozen, freeze_message, thaw_message,
                          FrozenMessage, FrozenMetaMessage,
                          FrozenUnknownMetaMessage)
@@ -27,3 +28,24 @@ def test_thawed_message_is_copy():
 def test_is_frozen():
     assert is_frozen(FrozenMessage('note_on'))
     assert not is_frozen(Message('note_on'))
+
+
+def test_frozen_repr():
+    msg = FrozenMessage('note_on', channel=1, note=2, time=3)
+    msg_eval = eval(repr(msg))
+    assert type(msg_eval) == Message
+    assert msg == msg_eval
+
+
+def test_frozen_meta_repr():
+    msg = FrozenMetaMessage('end_of_track', time=10)
+    msg_eval = eval(repr(msg))
+    assert type(msg_eval) == MetaMessage
+    assert msg == msg_eval
+
+
+def test_frozen_unknown_meta_repr():
+    msg = FrozenUnknownMetaMessage(type_byte=99, data=[1, 2], time=10)
+    msg_eval = eval(repr(msg))
+    assert type(msg_eval) == UnknownMetaMessage
+    assert msg == msg_eval


### PR DESCRIPTION
Fixes #162.

Example:
```Python console
>>> from mido import Message, MidiTrack, MidiFile
>>> m = Message('note_on', channel=1, note=2, time=3)
>>> m
Message('note_on', note=2, velocity=64, channel=1, time=3)
>>> t = MidiTrack([Message('note_on', channel=1, note=2, time=3),
... Message('note_off', channel=1, note=2, time=3)])
>>> t
MidiTrack([
  Message('note_on', note=2, velocity=64, channel=1, time=3),
  Message('note_off', note=2, velocity=64, channel=1, time=3)])
>>> f = MidiFile(type=1, ticks_per_beat=123, tracks=[t])
>>> f
MidiFile(type=1, ticks_per_beat=123, tracks=[
  MidiTrack([
    Message('note_on', note=2, velocity=64, channel=1, time=3),
    Message('note_off', note=2, velocity=64, channel=1, time=3)])
])
>>> f2 = eval(repr(f))
>>> f2
MidiFile(type=1, ticks_per_beat=123, tracks=[
  MidiTrack([
    Message('note_on', note=2, velocity=64, channel=1, time=3),
    Message('note_off', note=2, velocity=64, channel=1, time=3)])
])
```

Design decisions:
  * output of str() for each of these classes is left as it was
  * repr is canonicalized to the actual MIDI data as much as possible.  Hence MidiFile parameters like "filename", "debug" etc. are ignored, and Frozen variants are represented in mutable form.
