### PR TITLE
Fixed broken flake8 invocation by moving its options to a config file.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = F401, C901, F901
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+max-complexity = 10

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst LICENSE tox.ini
+include README.rst LICENSE tox.ini .flake8
 recursive-include tests *.py
 recursive-include examples *.py
 recursive-include extras *.py

--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -531,9 +531,7 @@ class MetaMessage(BaseMessage):
         spec = _META_SPEC_BY_TYPE[self.type]
         data = spec.encode(self)
 
-        return ([0xff, spec.type_byte] +
-                encode_variable_int(len(data)) +
-                data)
+        return ([0xff, spec.type_byte] + encode_variable_int(len(data)) + data)
 
     def __repr__(self):
         spec = _META_SPEC_BY_TYPE[self.type]
@@ -575,6 +573,5 @@ class UnknownMetaMessage(MetaMessage):
         vars(self)[name] = value
 
     def bytes(self):
-        return ([0xff, self.type_byte] +
-                encode_variable_int(len(self.data)) +
-                list(self.data))
+        length = encode_variable_int(len(self.data))
+        return ([0xff, self.type_byte] + length + list(self.data))

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ commands = pip install -q -e .[dev]
            py.test . -rs -q 
            check-manifest -v
            sphinx-build docs {envtmpdir} -q -E
-           flake8 mido --ignore=F401
+           flake8 mido


### PR DESCRIPTION
Also fixed a couple of line that flake8 complained about.

Tox runs again without any errors (at least locally). I've silenced a few errors. We may want to go back and look into them in the future.
