### PR TITLE
Only copy ports list once in ports.multi_receive

### DIFF
--- a/mido/ports.py
+++ b/mido/ports.py
@@ -384,9 +384,9 @@ def multi_receive(ports, yield_ports=False, block=True):
 
     If block=False only pending messages will be yielded.
     """
+    ports = list(ports)
     while True:
         # Make a shuffled copy of the port list.
-        ports = list(ports)
         random.shuffle(ports)
 
         for port in ports:


### PR DESCRIPTION
This is tiny but I kept seeing it as I read through the code and eventually... :-D

In `ports.multi_receive`, you _do_ want to make a copy of the incoming `ports` list, but only once, not each time through the loop!  So I moved it out of the loop.