### PR TITLE
fix typo in environment variable name MIDO_DEAFULT_INPUT

### DIFF
--- a/bin/mido-ports
+++ b/bin/mido-ports
@@ -18,7 +18,7 @@ print()
 print_ports('Available input Ports:', mido.get_input_names())
 print_ports('Available output Ports:', mido.get_output_names())
 
-for name in ['MIDO_DEAFULT_INPUT',
+for name in ['MIDO_DEFAULT_INPUT',
              'MIDO_DEFAULT_OUTPUT',
              'MIDO_DEFAULT_IOPORT',
              'MIDO_BACKEND']:


### PR DESCRIPTION
fixes typo in environment variable name MIDO_DEAFULT_INPUT to MIDO_DEFAULT_INPUT