### PR TITLE
Completed repr() changes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,8 +16,7 @@ Release History
 * Improved MidiFile.play to avoid time drift. (Implemented by John
   Belmonte, pull request #161.)
 
-* New ``repr()`` format. (Original implementation by John Belmonte,
-  pull request #164.)
+* New ``repr()`` format. (Implemented by John Belmonte, pull request #164.)
 
 * Added ``msg.is_cc()`` method. Checks if message is a control change.
   Can also be used to check for a specific control change number, for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Mido is a library for working with MIDI messages and ports:
    >>> msg.bytes()
    [144, 60, 64]
    >>> msg.copy(channel=2)
-   <message note_on channel=2 note=60 velocity=64 time=0>
+   Message('note_on', channel=2, note=60, velocity=64, time=0)
 
 .. code-block:: python
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -13,7 +13,7 @@ create a new message::
     >>> from mido import Message
     >>> msg = Message('note_on', note=60)
     >>> msg
-    <message note_on channel=0 note=60 velocity=64 time=0>
+    Message('note_on', channel=0, note=60, velocity=64, time=0)
 
 .. note::
 
@@ -37,7 +37,7 @@ Attributes are also settable but this should be avoided. It's better
 to use ``msg.copy()``::
 
     >>> msg.copy(note=100, velocity=127)
-    <message note_on channel=2 note=100 velocity=127 time=0)
+    Message('note_on', channel=0, note=100, velocity=127, time=0)
 
 Type and value checks are done when you pass parameters or assign to
 attributes, and the appropriate exceptions are raised. This ensures

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -7,12 +7,12 @@ attributes will vary depending on message type.
 To create a new message::
 
     >>> mido.Message('note_on')
-    <message note_on channel=0 note=0 velocity=64 time=0>
+    Message('note_on', channel=0, note=0, velocity=64, time=0)
 
 You can pass attributes as keyword arguments::
 
     >>> mido.Message('note_on', note=100, velocity=3, time=6.2)
-    <message note_on channel=0 note=100 velocity=3 time=6.2>
+    Message('note_on', channel=0, note=100, velocity=3, time=6.2)
 
 All attributes will default to 0. The exceptions are ``velocity``,
 which defaults to 64 (middle velocity) and ``data`` which defaults to
@@ -33,7 +33,7 @@ Attributes are also settable but it's always better to use
 ``msg.copy()``::
 
     >>> msg.copy(note=99, time=100.0)
-    <message note_on channel=0 note=99 velocity=64 time=100.0>
+    Message('note_on', channel=0, note=99, velocity=64, time=100.0)
 
 .. note:: Mido always makes a copy of messages instead of modifying
           them so if you do the same you have immutable messages in
@@ -69,7 +69,7 @@ You can convert a message to MIDI bytes with one of these methods:
 
     >>> msg = mido.Message('note_on')
     >>> msg
-    <message note_on channel=0 note=0 velocity=64 time=0>
+    Message('note_on', channel=0, note=0, velocity=64, time=0)
     >>> msg.bytes()
     [144, 0, 64]
     >>> msg.bin()
@@ -132,7 +132,7 @@ the payload of the message::
 
     >>> msg = Message('sysex', data=[1, 2, 3])
     >>> msg
-    <message sysex data=(1, 2, 3) time=0>
+    Message('sysex', data=(1, 2, 3), time=0)
     >>> msg.hex()
     'F0 01 02 03 F7'
 
@@ -142,7 +142,7 @@ You can also extend the existing data::
    >>> msg.data += [4, 5]
    >>> msg.data += [6, 7, 8]
    >>> msg
-   <message sysex data=(1, 2, 3, 4, 5, 6, 7, 8) time=0>
+   Message('sysex', data=(1, 2, 3, 4, 5, 6, 7, 8), time=0)
 
 Any sequence of integers is allowed, and type and range checking is
 applied to each data byte. These are all valid::
@@ -159,4 +159,4 @@ For example::
     >>> msg = Message('sysex', data=bytearray(b'ABC'))
     >>> msg.data += bytearray(b'DEF')
     >>> msg
-    <message sysex data=(65, 66, 67, 68, 69, 70) time=0>
+    Message('sysex', data=(65, 66, 67, 68, 69, 70), time=0)

--- a/docs/meta_message_types.rst
+++ b/docs/meta_message_types.rst
@@ -250,7 +250,7 @@ described below.
 
 These are also visible in the ``repr()`` string::
 
-    <unknown meta message type_byte=0x## data=[...], time=0>
+    UnknownMetaMessage(type_byte=251, data=(1, 2, 3), time=0>
 
 
 Implementing New Meta Messages
@@ -260,7 +260,7 @@ If you come across a meta message which is not implemented, or you
 want to use a custom meta message, you can add it by writing a new
 meta message spec::
 
-    from mido.midifiles import MetaSpec, add_meta_spec
+    from mido.midifiles.meta import MetaSpec, add_meta_spec
 
     class MetaSpec_light_color(MetaSpec):
         type_byte = 0xf0
@@ -300,7 +300,7 @@ and create messages in the usual way::
 
     >>> from mido import MetaMessage
     >>> MetaMessage('light_color', r=120, g=60, b=10)
-    <meta message light_color r=120 g=60 b=10 time=0>
+    MetaMessage('light_color', r=120, g=60, b=10, time=0)
 
 and the new message type will now work when reading and writing MIDI
 files.

--- a/docs/midi_files.rst
+++ b/docs/midi_files.rst
@@ -148,7 +148,7 @@ usual way, for example::
 
     >>> from mido import MetaMessage
     >>> MetaMessage('key_signature', key='C#', mode='major')
-    <meta message key_signature key='C#' mode='major' time=0>
+    MetaMessage('key_signature', key='C#', mode='major', time=0)
 
 You can tell meta messages apart from normal messages with::
 

--- a/docs/parsing.rst
+++ b/docs/parsing.rst
@@ -12,11 +12,11 @@ data bytes and use a stop byte instead.)
 Mido comes with a parser that turns MIDI bytes into messages. You can create a parser object, or call one of the utility functions::
 
     >>> mido.parse([0x92, 0x10, 0x20])
-    <message note_on channel=0 note=16 velocity=32 time=0>
+    Message('note_on', channel=2, note=16, velocity=32, time=0)
 
     >>> mido.parse_all([0x92, 0x10, 0x20, 0x82, 0x10, 0x20])
-    [<message note_on channel=2 note=16 velocity=32 time=0>,
-     <message note_off channel=2 note=16 velocity=32 time=0>]
+    [Message('note_on', channel=2, note=16, velocity=32, time=0),
+     Message('note_off', channel=2, note=16, velocity=32, time=0)]
 
 These functions are just shortcuts for the full ``Parser`` class. This
 is the parser used inside input ports to parse incoming messages.
@@ -27,13 +27,13 @@ Here are a few examples of how it can be used::
     >>> p.pending()
     1
     >>> p.get_message()
-    <message note_on channel=0 note=16 velocity=32 time=0>
+    Message('note_on', channel=0, note=16, velocity=32, time=0)
 
     >>> p.feed_byte(0x90)
     >>> p.feed_byte(0x10)
     >>> p.feed_byte(0x20)
     >>> p.feed([0x80, 0x10, 0x20])
-    <message note_on channel=0 note=16 velocity=32 time=0>
+    Message('note_on', channel=0, note=16, velocity=32, time=0)
 
 ``feed()`` accepts any iterable that generates integers in 0..255. The
 parser will skip and stray status bytes or data bytes, so you can

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,7 +1,7 @@
 Resources
 =========
 
-* `MIDI Manufacturers Association <http://midi.org/>`_ (midi.org)
+* `MIDI Association <http://midi.org/>`_ (midi.org)
 
 * `Table of MIDI Messages <http://www.midi.org/techspecs/midimessages.php>`_
   (midi.org)

--- a/docs/string_encoding.rst
+++ b/docs/string_encoding.rst
@@ -14,7 +14,7 @@ To encode a message, simply call ``str()`` on it::
 To convert the other way (new method in 1.2)::
 
     >>> mido.Message.from_str('control_change control=1 value=122')
-    <message control_change channel=0 control=1 value=122 time=0>
+    Message('control_change', channel=0, control=1, value=122, time=0)
 
 Alternatively, you can call the ``format_as_string`` function directly:
 
@@ -58,14 +58,14 @@ Parsing
 To parse a message, you can use ``mido.parse_string()``::
 
     >>> parse_string('control_change control=1 value=122 time=0.5')
-    <message control_change channel=0 control=1 value=122 time=0.5>
+    Message('control_change', channel=0, control=1, value=122, time=0.5)
 
 Parameters that are left out are set to their default
 values. ``ValueError`` is raised if the message could not be
 parsed. Extra whitespace is ignored::
 
     >>> parse_string('  control_change   control=1  value=122')
-    <message control_change channel=0 control=1 value=122 time=0>
+    Message('control_change', channel=0, control=1, value=122, time=0)
 
 To parse messages from a stream, you can use
 ``mido.messages.parse_string_stream()``::

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -472,11 +472,6 @@ class MidiFile(object):
                 else:
                     print('{!r}'.format(msg))
 
-    def __str__(self):
-        return '<midi file {!r} type {}, {} tracks, {} messages>'.format(
-            self.filename, self.type, len(self.tracks),
-            sum([len(track) for track in self.tracks]))
-
     def __repr__(self):
         tracks_str = ',\n'.join(repr(track) for track in self.tracks)
         tracks_str = '\n'.join('  ' + line for line in tracks_str.splitlines())

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -480,8 +480,8 @@ class MidiFile(object):
     def __repr__(self):
         tracks_str = ',\n'.join(repr(track) for track in self.tracks)
         tracks_str = '\n'.join('  ' + line for line in tracks_str.splitlines())
-        tracks_str = (', tracks=[\n%s\n]' % tracks_str) if self.tracks else ''
-        return 'MidiFile(type=%s, ticks_per_beat=%s%s)' % (
+        tracks_str = (', tracks=[\n{}\n]'.format(tracks_str)) if self.tracks else ''
+        return 'MidiFile(type={}, ticks_per_beat={}{})'.format(
             self.type, self.ticks_per_beat, tracks_str)
 
     # The context manager has no purpose but is kept around since it was

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -473,9 +473,12 @@ class MidiFile(object):
                     print('{!r}'.format(msg))
 
     def __repr__(self):
-        tracks_str = ',\n'.join(repr(track) for track in self.tracks)
-        tracks_str = '\n'.join('  ' + line for line in tracks_str.splitlines())
-        tracks_str = (', tracks=[\n{}\n]'.format(tracks_str)) if self.tracks else ''
+        if self.tracks:
+            tracks_str = ',\n'.join(repr(track) for track in self.tracks)
+            tracks_str = '  ' + tracks_str.replace('\n', '\n  ')
+            tracks_str = ', tracks=[\n{}\n]'.format(tracks_str)
+        else:
+            tracks_str = ''
         return 'MidiFile(type={}, ticks_per_beat={}{})'.format(
             self.type, self.ticks_per_beat, tracks_str)
 

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -54,11 +54,12 @@ class MidiTrack(list):
         return '<midi track {!r} {} messages>'.format(self.name, len(self))
 
     def __repr__(self):
-        messages = ''
         if len(self) > 0:
-            template = '[\n  %s]' if len(self) > 1 else '[%s]'
-            messages = template % ',\n  '.join(repr(m) for m in self)
-        return 'MidiTrack(%s)' % messages
+            template = '[\n  {}]' if len(self) > 1 else '[{}]'
+            messages = template.format(',\n  '.join(repr(m) for m in self))
+        else:
+            messages = ''
+        return 'MidiTrack({})'.format(messages)
 
 
 def _to_abstime(messages):

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -50,9 +50,6 @@ class MidiTrack(list):
     def __mul__(self, other):
         return self.__class__(list.__mul__(self, other))
 
-    def __str__(self):
-        return '<midi track {!r} {} messages>'.format(self.name, len(self))
-
     def __repr__(self):
         if len(self) > 0:
             template = '[\n  {}]' if len(self) > 1 else '[{}]'


### PR DESCRIPTION
* Switched from % syntax to .format().
* Updated the docs to use the new repr() format.
* Fixed a mistake in a docs example. (Import from wrong module.)
* Updated the name of the MIDI Association.
* Removed the `__str__()` methods from MidiTrack and MidiFile.

The code in `MidiFile.__repr__()` and `MidiTrack().__repr__()` is a bit hard to follow but it's OK for now.



