### PR TITLE
documentation now refers to "discussions"; closes #265

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,21 +115,6 @@ Mido is released under the terms of the `MIT license
 Questions and suggestions
 -------------------------
 
-Please ask questions about Mido at
-https://groups.google.com/forum/#!forum/mido-community.
-
-This mailing list was created to give both the user community a place to ask
-and hopefully also answer questions and for the developers a space to discuss
-Mido development. The success of the mailing list will depend on the community
-effort to also answer questions.
-
-
-Looking for maintainers
------------------------
-
-This project is looking for somebody to take over the maintenance since the
-original author @olemb is busy with other projects. We look for somebody or a
-group of people who care about the code and would like to steer this project in
-future by discussing proposals, reviewing pull requests, and looking over
-issues. Please write to mido-community@googlegroups.com if you would like to
-help out with maintenance.
+For questions and proposals which may not fit into issues or pull requests, we
+recommend to ask and discuss on `Discussions
+<https://github.com/mido/mido/discussions>`_.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,8 +6,8 @@ Questions
 ---------
 
 If you have questions about contributing code or suggestions
-for how to make contributing easier, please write to
-https://groups.google.com/forum/#!forum/mido-community.
+for how to make contributing easier, please write at
+https://github.com/mido/mido/discussions.
 
 
 Installing for developers

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -8,9 +8,6 @@ a list of ideas.
 Near Future
 -----------
 
-* create a place for general discussion:
-  Now exists: https://groups.google.com/forum/#!forum/mido-community
-
 * a `PEP <https://www.python.org/dev/peps/>`_ like process for new
   features and major changes?
 


### PR DESCRIPTION
Also removed block about looking for maintainers although we still welcome people who want to help with code review, issues, and planning.