### PR TITLE
Make `UnknownMetaMessage` robust to faulty MIDIs

### DIFF
--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -540,14 +540,14 @@ class MetaMessage(BaseMessage):
 
 
 class UnknownMetaMessage(MetaMessage):
-    def __init__(self, type_byte, data=None, time=0):
+    def __init__(self, type_byte, data=None, time=0, type='unknown_meta'):
         if data is None:
             data = ()
         else:
             data = tuple(data)
 
         vars(self).update({
-            'type': 'unknown_meta',
+            'type': type,
             'type_byte': type_byte,
             'data': data,
             'time': time})


### PR DESCRIPTION
For some MIDI files the parameter `type` is passed to the constructor resulting in an TypeError. This workaround should fix this without changing anything else.