### PR TITLE
Fix PortServer disconnect crash in Python 3

### DIFF
--- a/mido/sockets.py
+++ b/mido/sockets.py
@@ -104,7 +104,7 @@ class SocketPort(BaseIOPort):
                 byte = self._rfile.read(1)
             except socket.error as err:
                 raise IOError(err.args[1])
-            if byte == '':
+            if len(byte) == 0:
                 # The other end has disconnected.
                 self.close()
                 break


### PR DESCRIPTION
Fixes #290.  More info is available [here](https://github.com/kyleclaassen/mido/commit/f38bbd703b4114c2bd70ac7e4cad2d58d01c44e7#commitcomment-47639569).