### PR TITLE
in testing and contribution docs, use "main" instead of "master"; closes #272

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -96,9 +96,9 @@ Update the stable branch (if this is a stable release):
 ::
 
    git checkout stable
-   git pull . master
+   git pull . main
    git push
-   git checkout master
+   git checkout main
 
 
 Update Read the Docs


### PR DESCRIPTION
I need to also actually rename the branch itself.