### PR TITLE
Fix for duplicated devices in mido output

### DIFF
--- a/mido/backends/rtmidi.py
+++ b/mido/backends/rtmidi.py
@@ -45,7 +45,7 @@ def _get_api_id(name=None):
 
 
 def get_devices(api=None, **kwargs):
-    devices = []
+    devices = {}
 
     rtapi = _get_api_id(api)
 
@@ -55,14 +55,15 @@ def get_devices(api=None, **kwargs):
     output_names = mo.get_ports()
 
     for name in input_names + output_names:
-        devices.append({'name': name,
-                        'is_input': name in input_names,
-                        'is_output': name in output_names,
-                        })
+        if name not in devices:
+            devices[name] = {'name': name,
+                            'is_input': name in input_names,
+                            'is_output': name in output_names,
+                            }
 
     mi.delete()
     mo.delete()
-    return devices
+    return list(devices.values())
 
 
 def get_api_names():

--- a/mido/backends/rtmidi_python.py
+++ b/mido/backends/rtmidi_python.py
@@ -31,18 +31,19 @@ else:
 
 
 def get_devices(api=None, **kwargs):
-    devices = []
+    devices = {}
 
     input_names = rtmidi.MidiIn().ports
     output_names = rtmidi.MidiOut().ports
 
     for name in input_names + output_names:
-        devices.append({'name': name,
-                        'is_input': name in input_names,
-                        'is_output': name in output_names,
-                        })
+        if name not in devices:
+            devices[name] = {'name': name,
+                            'is_input': name in input_names,
+                            'is_output': name in output_names,
+                            }
 
-    return devices
+    return list(devices.values())
 
 
 class PortCommon(object):


### PR DESCRIPTION
Devices with both input and output were listed twice. Before my changes:
```python
>>> import mido
>>> mido.get_input_names()
['Midi Through:Midi Through Port-0 14:0', 'Neutron(1):Neutron(1) MIDI 1 16:0', 'Keybow 2040:Keybow 2040 MIDI 1 20:0', 'Midi Through:Midi Through Port-0 14:0', 'Neutron(1):Neutron(1) MIDI 1 16:0', 'Keybow 2040:Keybow 2040 MIDI 1 20:0']
>>> import mido.backends.rtmidi
>>> mido.backends.rtmidi.get_devices()
[{'name': 'Midi Through:Midi Through Port-0 14:0', 'is_input': True, 'is_output': True}, {'name': 'Neutron(1):Neutron(1) MIDI 1 16:0', 'is_input': True, 'is_output': True}, {'name': 'Keybow 2040:Keybow 2040 MIDI 1 20:0', 'is_input': True, 'is_output': True}, {'name': 'Midi Through:Midi Through Port-0 14:0', 'is_input': True, 'is_output': True}, {'name': 'Neutron(1):Neutron(1) MIDI 1 16:0', 'is_input': True, 'is_output': True}, {'name': 'Keybow 2040:Keybow 2040 MIDI 1 20:0', 'is_input': True, 'is_output': True}]
```
After my changes:
```python
>>> import mido
>>> mido.get_input_names()
['Midi Through:Midi Through Port-0 14:0', 'Neutron(1):Neutron(1) MIDI 1 16:0', 'Keybow 2040:Keybow 2040 MIDI 1 20:0']
>>> import mido.backends.rtmidi
>>> mido.backends.rtmidi.get_devices()
[{'name': 'Midi Through:Midi Through Port-0 14:0', 'is_input': True, 'is_output': True}, {'name': 'Neutron(1):Neutron(1) MIDI 1 16:0', 'is_input': True, 'is_output': True}, {'name': 'Keybow 2040:Keybow 2040 MIDI 1 20:0', 'is_input': True, 'is_output': True}]
```