### PR TITLE
Implement issue #329 (callback with arguments for input-ports)

### DIFF
--- a/examples/callback_w_args/callback_w_args.py
+++ b/examples/callback_w_args/callback_w_args.py
@@ -1,0 +1,15 @@
+import mido
+import queue
+import time
+
+rtmidi = mido.Backend('mido.backends.rtmidi')
+
+def myfunc(msg, q):
+    print(f'Got message: {msg}')
+    q.put(msg)
+
+q = queue.Queue()
+input_ = rtmidi.open_input('testing', virtual=True, callback_w_args=(myfunc, q))
+
+while True:
+    time.sleep(1)

--- a/mido/backends/backend.py
+++ b/mido/backends/backend.py
@@ -68,7 +68,7 @@ class Backend(object):
             kwargs['api'] = self.api
         return kwargs
 
-    def open_input(self, name=None, virtual=False, callback=None, **kwargs):
+    def open_input(self, name=None, virtual=False, callback=None, callback_w_args=None, **kwargs):
         """Open an input port.
 
         If the environment variable MIDO_DEFAULT_INPUT is set,
@@ -82,8 +82,15 @@ class Backend(object):
           A callback function to be called when a new message arrives.
           The function should take one argument (the message).
           Raises IOError if not supported by the backend.
+
+        callback_w_args=None
+          A tuple with a callback function to be called (and its
+          argument) when a new message arrives.
+          The function should take two arguments (the message and the
+          second value of this tuple (the argument)).
+          Raises IOError if not supported by the backend.
         """
-        kwargs.update(dict(virtual=virtual, callback=callback))
+        kwargs.update(dict(virtual=virtual, callback=callback, callback_w_args=callback_w_args))
 
         if name is None:
             name = self._env('MIDO_DEFAULT_INPUT')
@@ -112,7 +119,8 @@ class Backend(object):
         return self.module.Output(name, **self._add_api(kwargs))
 
     def open_ioport(self, name=None, virtual=False,
-                    callback=None, autoreset=False, **kwargs):
+                    callback=None, callback_w_args=None,
+                    autoreset=False, **kwargs):
         """Open a port for input and output.
 
         If the environment variable MIDO_DEFAULT_IOPORT is set,
@@ -127,11 +135,19 @@ class Backend(object):
           The function should take one argument (the message).
           Raises IOError if not supported by the backend.
 
+        callback_w_args=None
+          A tuple with a callback function to be called (and its
+          argument) when a new message arrives.
+          The function should take two arguments (the message and the
+          second value of this tuple (the argument)).
+          Raises IOError if not supported by the backend.
+
         autoreset=False
           Automatically send all_notes_off and reset_all_controllers
           on all channels. This is the same as calling `port.reset()`.
         """
         kwargs.update(dict(virtual=virtual, callback=callback,
+                           callback_w_args=callback_w_args,
                            autoreset=autoreset))
 
         if name is None:

--- a/mido/backends/pygame.py
+++ b/mido/backends/pygame.py
@@ -67,7 +67,7 @@ class PortCommon(object):
         if kwargs.get('virtual'):
             raise ValueError('virtual ports are not supported'
                              ' by the Pygame backend')
-        elif kwargs.get('callback'):
+        elif kwargs.get('callback') or kwargs.get('callback_w_args'):
             raise ValueError('callbacks are not supported'
                              ' by the Pygame backend')
 

--- a/mido/ports.py
+++ b/mido/ports.py
@@ -166,6 +166,9 @@ class BaseInput(BasePort):
         if hasattr(self, 'callback') and self.callback is not None:
             raise ValueError('a callback is set for this port')
 
+        if hasattr(self, 'callback_w_args') and self.callback_w_args is not None:
+            raise ValueError('a callback_w_args is set for this port')
+
     def _receive(self, block=True):
         pass
 


### PR DESCRIPTION
Introduces 'callback_w_args' callback-parameter for input-ports.
This implements issue #329 