### PR TITLE
Support running status

### DIFF
--- a/mido/tokenizer.py
+++ b/mido/tokenizer.py
@@ -12,6 +12,7 @@ class Tokenizer(object):
         """Create a new decoder."""
 
         self._status = 0
+        self._last_status = 0
         self._bytes = []
         self._messages = deque()
         self._datalen = 0
@@ -59,7 +60,12 @@ class Tokenizer(object):
             if len(self._bytes) == self._len:
                 # Complete message.
                 self._messages.append(self._bytes)
+                self._last_status = self._status
                 self._status = 0
+        elif self._last_status:
+            # Running status
+            self._feed_status_byte(self._last_status)
+            self._feed_data_byte(byte)
         else:
             # Ignore stray data byte.
             pass

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -52,4 +52,12 @@ def test_sysex_inside_sysex():
 
 def test_stray_data_bytes():
     """Data bytes outside messages should be ignored."""
-    assert tokenize([0, 1, 0x90, 2, 3, 4, 5, 0xf8, 6]) == [[0x90, 2, 3], [0xf8]]
+    assert tokenize([0, 1, 0x90, 2, 3, 0xf8, 6]) == [[0x90, 2, 3], [0xf8]]
+
+
+def test_running_status():
+    """The last known status byte should be reused if omitted in a message."""
+    assert tokenize([0x9a, 3, 127, 3, 64, 3, 0, 0xb0, 2, 3, 4, 5]) == [
+        [0x9a, 3, 127], [0x9a, 3, 64], [0x9a, 3, 0],
+        [0xb0, 2, 3], [0xb0, 4, 5]
+    ]


### PR DESCRIPTION
We're now storing the last status byte whenever a message with at least one data byte is composed. If a message starts with a data byte this status byte will get injected. This is according to the MIDI spec: [running status](http://midi.teragonaudio.com/tech/midispec/run.htm).

So the following two inputs are considered equal now:

    0x9a, 3, 127, 0x9a, 3, 64, 0x9a, 3, 0
    0x9a, 3, 127,       3, 64,       3, 0   

I'm not sure about the right base branch, I'll rebase accordingly if needed.