### PR TITLE
update parsing.rst

### DIFF
--- a/docs/parsing.rst
+++ b/docs/parsing.rst
@@ -1,7 +1,7 @@
 Parsing MIDI Bytes
 ==================
 
-MIDI is a binary protocol. Each each message is encoded as a status byte
+MIDI is a binary protocol. Each message is encoded as a status byte
 followed by up to three data bytes. (Sysex messages can have any number of
 data bytes and use a stop byte instead.)
 


### PR DESCRIPTION
Typo in second sentence:

WAS: 
- Each each message is encoded as a status byte
followed by up to three data bytes.

NOW: 
- Each message is encoded as a status byte
followed by up to three data bytes.