### PR TITLE
Fix `copy` method on UnknownMetaMessage class

### DIFF
--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -504,6 +504,10 @@ class MetaMessage(BaseMessage):
 
         attrs = vars(self).copy()
         attrs.update(overrides)
+
+        if self.type == 'unknown_meta':
+            attrs.pop('type')
+
         return self.__class__(**attrs)
 
     # FrozenMetaMessage overrides __setattr__() but we still need to


### PR DESCRIPTION
When using the `copy` method on UnknownMetaMessage class, it raises TypeError.

```.py
>>> import mido
>>> msg = mido.UnknownMetaMessage(type_byte=8)
>>> msg2 = msg.copy(time=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/trueroad/.local/lib/python3.9/site-packages/mido/midifiles/meta.py", line 507, in copy
    return self.__class__(**attrs)
TypeError: __init__() got an unexpected keyword argument 'type'
```

This pull request fixes it.
