### PR TITLE
mido: backends: portmidi: Fix port opening

### DIFF
--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -121,7 +121,7 @@ class PortCommon(object):
 
         if self.is_input:
             _check_error(pm.lib.Pm_OpenInput(
-                         pm.byref(self._stream),
+                         self._stream,
                          device['id'],  # Input device
                          pm.null,       # Input driver info
                          1000,          # Buffer size
@@ -129,7 +129,7 @@ class PortCommon(object):
                          pm.null))      # Time info
         else:
             _check_error(pm.lib.Pm_OpenOutput(
-                         pm.byref(self._stream),
+                         self._stream,
                          device['id'],  # Output device
                          pm.null,       # Output diver info
                          0,             # Buffer size


### PR DESCRIPTION
* portmidi_init.by_ref doesn't exist and it seems to be working fine just by passing the pointer as is

Change-Id: I4e66d9a049197128ff73e1c4ffda9d5567f7b0d8
