### PR TITLE
backends: Fix typos in docstrings

### DIFF
--- a/mido/backends/backend.py
+++ b/mido/backends/backend.py
@@ -72,7 +72,7 @@ class Backend(object):
         """Open an input port.
 
         If the environment variable MIDO_DEFAULT_INPUT is set,
-        if will override the default port.
+        it will override the default port.
 
         virtual=False
           Passing True opens a new port that other applications can
@@ -94,7 +94,7 @@ class Backend(object):
         """Open an output port.
 
         If the environment variable MIDO_DEFAULT_OUTPUT is set,
-        if will override the default port.
+        it will override the default port.
 
         virtual=False
           Passing True opens a new port that other applications can
@@ -116,7 +116,7 @@ class Backend(object):
         """Open a port for input and output.
 
         If the environment variable MIDO_DEFAULT_IOPORT is set,
-        if will override the default port.
+        it will override the default port.
 
         virtual=False
           Passing True opens a new port that other applications can


### PR DESCRIPTION
"if will" ==> "it will"