### PR TITLE
docs: Fix example code for parsing

### DIFF
--- a/docs/parsing.rst
+++ b/docs/parsing.rst
@@ -33,7 +33,12 @@ Here are a few examples of how it can be used::
     >>> p.feed_byte(0x10)
     >>> p.feed_byte(0x20)
     >>> p.feed([0x80, 0x10, 0x20])
+    >>> p.pending()
+    2
+    >>> p.get_message()
     Message('note_on', channel=0, note=16, velocity=32, time=0)
+    >>> p.get_message()
+    Message('note_off', channel=0, note=16, velocity=32, time=0)
 
 ``feed()`` accepts any iterable that generates integers in 0..255. The
 parser will skip and stray status bytes or data bytes, so you can


### PR DESCRIPTION
Correct the intended commands and output which demo the `Parser().feed_byte()` and `Parser().feed()` use.