### PR TITLE
Remove remnants of Python 2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Full documentation at https://mido.readthedocs.io/
 Main Features
 -------------
 
-* works in Python 2 and 3.
+* works in Python 3.
 
 * convenient message objects.
 

--- a/bin/mido-connect
+++ b/bin/mido-connect
@@ -1,9 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Forward all messages from one or more ports to server.
 """
 import argparse
+
 import mido
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -19,6 +21,7 @@ def parse_args():
         help='input ports to listen to')
 
     return parser.parse_args()
+
 
 args = parse_args()
 

--- a/bin/mido-play
+++ b/bin/mido-play
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Play MIDI file on output port.
 
@@ -10,11 +10,12 @@ Todo:
 
   - add option for printing messages
 """
-from __future__ import print_function, division
-import sys
 import argparse
+import sys
+
 import mido
 from mido import MidiFile, Message, tempo2bpm
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -49,8 +50,8 @@ def play_file(output, filename, print_messages):
     print('Playing {}.'.format(midi_file.filename))
     length = midi_file.length
     print('Song length: {} minutes, {} seconds.'.format(
-            int(length / 60),
-            int(length % 60)))
+        int(length / 60),
+        int(length % 60)))
     print('Tracks:')
     for i, track in enumerate(midi_file.tracks):
         print('  {:2d}: {!r}'.format(i, track.name.strip()))
@@ -82,6 +83,7 @@ def main():
                 output.reset()
     except KeyboardInterrupt:
         pass
+
 
 args = parse_args()
 

--- a/bin/mido-ports
+++ b/bin/mido-ports
@@ -1,18 +1,19 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 List available PortMidi ports.
 """
 
-from __future__ import print_function
 import os
-import sys
+
 import mido
+
 
 def print_ports(heading, port_names):
     print(heading)
     for name in port_names:
         print("    '{}'".format(name))
     print()
+
 
 print()
 print_ports('Available input Ports:', mido.get_input_names())
@@ -30,4 +31,3 @@ for name in ['MIDO_DEFAULT_INPUT',
 print()
 print('Using backend {}.'.format(mido.backend.name))
 print()
-

--- a/bin/mido-serve
+++ b/bin/mido-serve
@@ -1,12 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Serve one or more output ports. Every message received on any of the
 connected sockets will be sent to every output port.
 """
 import argparse
+
 import mido
 from mido import sockets
 from mido.ports import MultiPort
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -22,6 +24,7 @@ def parse_args():
         help='output port to serve')
 
     return parser.parse_args()
+
 
 args = parse_args()
 

--- a/docs/backends/index.rst
+++ b/docs/backends/index.rst
@@ -76,10 +76,10 @@ three environment variables::
 
 For example::
 
-    $ MIDO_DEFAULT_INPUT='SH-201' python program.py
+    $ MIDO_DEFAULT_INPUT='SH-201' python3 program.py
 
 or::
 
     $ export MIDO_DEFAULT_OUTPUT='Integra-7'
-    $ python program1.py
-    $ python program2.py
+    $ python3 program1.py
+    $ python3 program2.py

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,8 +75,8 @@ fails to upload I can roll back and fix it before I push my changes.
 
     rm -rf dist/*
 
-    python setup.py bdist_wheel --universal
-    python setup.py sdist
+    python3 setup.py bdist_wheel --universal
+    python3 setup.py sdist
 
     twine upload dist/*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ This document is available at https://mido.readthedocs.io/
 
 To build locally::
 
-    python setup.py docs
+    python3 setup.py docs
 
 This requires Sphinx. The resulting files can be found in
 ``docs/_build/``.

--- a/examples/backends/rtm.py
+++ b/examples/backends/rtm.py
@@ -16,8 +16,8 @@ http://github.com/superquadratic/rtmidi-python
 Other than that, it works exactly like the included python-rtmidi
 backend.
 """
-from __future__ import absolute_import
 import rtmidi_python as rtmidi
+
 from mido.ports import BaseInput, BaseOutput
 
 
@@ -49,6 +49,7 @@ class PortCommon(object):
                     self._parser.feed(message)
                     for message in self._parser:
                         callback(message)
+
                 self._rt.callback = self._callback = callback_wrapper
                 self._has_callback = True
             else:

--- a/examples/midifiles/create_midi_file.py
+++ b/examples/midifiles/create_midi_file.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Create a new MIDI file with some random notes.
 
 The file is saved to test.mid.
 """
-from __future__ import division
 import random
 import sys
+
 from mido import Message, MidiFile, MidiTrack, MAX_PITCHWHEEL
 
-notes = [64, 64+7, 64+12]
+notes = [64, 64 + 7, 64 + 12]
 
 outfile = MidiFile()
 

--- a/examples/midifiles/play_midi_file.py
+++ b/examples/midifiles/play_midi_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Play MIDI file on output port.
 
@@ -7,8 +7,9 @@ Run with (for example):
     ./play_midi_file.py 'SH-201 MIDI 1' 'test.mid'
 """
 import sys
-import mido
 import time
+
+import mido
 from mido import MidiFile
 
 filename = sys.argv[1]
@@ -25,7 +26,7 @@ with mido.open_output(portname) as output:
             print(message)
             output.send(message)
         print('play time: {:.2f} s (expected {:.2f})'.format(
-                time.time() - t0, midifile.length))
+            time.time() - t0, midifile.length))
 
     except KeyboardInterrupt:
         print()

--- a/examples/midifiles/print_midi_file.py
+++ b/examples/midifiles/print_midi_file.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Open a MIDI file and print every message in every track.
 
 Support for MIDI files is still experimental.
 """
 import sys
+
 from mido import MidiFile
 
 if __name__ == '__main__':

--- a/examples/midifiles/show_midifile.py
+++ b/examples/midifiles/show_midifile.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
-import sys
+#!/usr/bin/env python3
 import argparse
+
 import mido
 
 

--- a/examples/ports/input_filter.py
+++ b/examples/ports/input_filter.py
@@ -1,14 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Receive messages on the input port and print messages with a specific
 channel (defaults to 0).
 
 Usage:
 
-    python example_input_filter.py portname [CHANNEL] [...]
+    python3 example_input_filter.py portname [CHANNEL] [...]
 """
-from __future__ import print_function
 import sys
+
 import mido
 
 
@@ -22,7 +22,7 @@ def accept_notes(port):
 if len(sys.argv) > 1:
     portname = sys.argv[1]
 else:
-    portname = None   # Use default port
+    portname = None  # Use default port
 
 try:
     with mido.open_input(portname) as port:

--- a/examples/ports/list_ports.py
+++ b/examples/ports/list_ports.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 List available ports.
 
 This is a simple version of mido-ports.
 """
-from __future__ import print_function
 import mido
 
 

--- a/examples/ports/multi_receive.py
+++ b/examples/ports/multi_receive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Receive messages from multiple ports.
 """

--- a/examples/ports/nonblocking_receive.py
+++ b/examples/ports/nonblocking_receive.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Example of non-blocking reception from input port.
 """
-from __future__ import print_function
 import sys
 import time
+
 import mido
 
 if len(sys.argv) > 1:

--- a/examples/ports/queue_port.py
+++ b/examples/ports/queue_port.py
@@ -2,14 +2,10 @@
 
 This allows you to create internal ports to send messages between threads.
 """
+import queue
+
 import mido
 from mido import ports
-
-try:
-    import queue
-except ImportError:
-    # Python 2.
-    import Queue as queue
 
 
 class QueuePort(ports.BaseIOPort):

--- a/examples/ports/receive.py
+++ b/examples/ports/receive.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Receive messages from the input port and print them out.
 """
-from __future__ import print_function
 import sys
+
 import mido
 
 if len(sys.argv) > 1:

--- a/examples/ports/send.py
+++ b/examples/ports/send.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Send random notes to the output port.
 """
 
-from __future__ import print_function
+import random
 import sys
 import time
-import random
+
 import mido
 from mido import Message
-
 
 if len(sys.argv) > 1:
     portname = sys.argv[1]

--- a/examples/sockets/forward_ports.py
+++ b/examples/sockets/forward_ports.py
@@ -1,12 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Forward all messages from one or more ports to server.
 
 Example:
 
-    python forward_ports.py localhost:8080 'Keyboard MIDI 1'
+    python3 forward_ports.py localhost:8080 'Keyboard MIDI 1'
 """
 import sys
+
 import mido
 
 host, port = mido.sockets.parse_address(sys.argv[1])

--- a/examples/sockets/serve_ports.py
+++ b/examples/sockets/serve_ports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Serve one or more output ports.
 
@@ -7,7 +7,7 @@ every output port.
 
 Example:
 
-    python serve_ports.py :8080 'SH-201' 'SD-20 Part A'
+    python3 serve_ports.py :8080 'SH-201' 'SD-20 Part A'
 
 This simply iterates through all incoming messages. More advanced and
 flexible servers can be written by calling the ``accept()`` and
@@ -15,6 +15,7 @@ flexible servers can be written by calling the ``accept()`` and
 an example.
 """
 import sys
+
 import mido
 from mido import sockets
 from mido.ports import MultiPort

--- a/examples/sockets/simple_client.py
+++ b/examples/sockets/simple_client.py
@@ -1,15 +1,16 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple client that sends program_change messages to server at timed
 intervals.
 
 Example:
 
-    python simple_client.py localhost:8080
+    python3 simple_client.py localhost:8080
 """
+import random
 import sys
 import time
-import random
+
 import mido
 
 if sys.argv[1:]:

--- a/examples/sockets/simple_server.py
+++ b/examples/sockets/simple_server.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Simple server that just prints every message it receives.
 
-    python simple_server.py localhost:8080
+    python3 simple_server.py localhost:8080
 """
 import sys
+
 from mido import sockets
 
 if sys.argv[1:]:

--- a/mido/__init__.py
+++ b/mido/__init__.py
@@ -89,22 +89,22 @@ Getting started:
     >>> get_input_names()
     ['MPK mini MIDI 1', 'SH-201']
 """
-from __future__ import absolute_import
 import os
-from .backends.backend import Backend
+
 from . import ports, sockets
+from .__about__ import (__version__, __author__, __author_email__,
+                        __url__, __license__)
+from .backends.backend import Backend
 from .messages import (Message, parse_string, parse_string_stream,
                        format_as_string, MIN_PITCHWHEEL, MAX_PITCHWHEEL,
                        MIN_SONGPOS, MAX_SONGPOS)
-from .parser import Parser, parse, parse_all
 from .midifiles import (MidiFile, MidiTrack, merge_tracks,
                         MetaMessage, UnknownMetaMessage,
                         bpm2tempo, tempo2bpm, tick2second, second2tick,
                         KeySignatureError)
+from .parser import Parser, parse, parse_all
 from .syx import read_syx_file, write_syx_file
 from .version import version_info
-from .__about__ import (__version__, __author__, __author_email__,
-                        __url__, __license__)
 
 # Prevent splat import.
 __all__ = []
@@ -137,4 +137,4 @@ def set_backend(name=None, load=False):
 
 set_backend()
 
-del os, absolute_import
+del os

--- a/mido/backends/pygame.py
+++ b/mido/backends/pygame.py
@@ -6,7 +6,6 @@ Pygame uses PortMidi, so this is perhaps not very useful.
 http://www.pygame.org/docs/ref/midi.html
 """
 
-from __future__ import absolute_import
 from pygame import midi
 from ..ports import BaseInput, BaseOutput
 
@@ -63,6 +62,7 @@ class PortCommon(object):
     """
     Mixin with common things for input and output ports.
     """
+
     def _open(self, **kwargs):
         if kwargs.get('virtual'):
             raise ValueError('virtual ports are not supported'
@@ -101,6 +101,7 @@ class Input(PortCommon, BaseInput):
     """
     PortMidi Input port
     """
+
     def _receive(self, block=True):
         # I get hanging notes if MAX_EVENTS > 1, so I'll have to
         # resort to calling Pm_Read() in a loop until there are no
@@ -115,6 +116,7 @@ class Output(PortCommon, BaseOutput):
     """
     PortMidi output port
     """
+
     def _send(self, message):
         if message.type == 'sysex':
             # Python 2 version of Pygame accepts a bytes or list here

--- a/mido/backends/rtmidi.py
+++ b/mido/backends/rtmidi.py
@@ -2,14 +2,13 @@
 
 http://pypi.python.org/pypi/python-rtmidi/
 """
-from __future__ import absolute_import
 import threading
 
 import rtmidi
-from .. import ports
-from ..messages import Message
 from ._parser_queue import ParserQueue
 from .rtmidi_utils import expand_alsa_port_name
+from .. import ports
+from ..messages import Message
 
 
 def _get_api_lookup():
@@ -72,7 +71,6 @@ def get_api_names():
 
 
 def _open_port(rt, name=None, client_name=None, virtual=False, api=None):
-
     if api == 'LINUX_ALSA':
         name = expand_alsa_port_name(rt.get_ports(), name)
 
@@ -183,7 +181,6 @@ class Output(PortCommon, ports.BaseOutput):
 
     def _open(self, client_name=None, virtual=False,
               api=None, callback=None, **kwargs):
-
         self.closed = True
         self._send_lock = threading.RLock()
 

--- a/mido/backends/rtmidi_python.py
+++ b/mido/backends/rtmidi_python.py
@@ -17,13 +17,12 @@ TODO:
   mido.backends.rtmidi.)There may be a way to remove this filtering.
 
 """
-from __future__ import absolute_import
+import queue
+
 import rtmidi_python as rtmidi
 # TODO: change this to a relative import if the backend is included in
 # the package.
 from ..ports import BaseInput, BaseOutput
-
-import queue
 
 
 def get_devices(api=None, **kwargs):

--- a/mido/messages/messages.py
+++ b/mido/messages/messages.py
@@ -1,8 +1,9 @@
 import re
-from .specs import make_msgdict, SPEC_BY_TYPE, REALTIME_TYPES
+
 from .checks import check_msgdict, check_value, check_data
 from .decode import decode_message
 from .encode import encode_message
+from .specs import make_msgdict, SPEC_BY_TYPE, REALTIME_TYPES
 from .strings import msg2str, str2msg
 
 
@@ -45,13 +46,13 @@ class BaseMessage(object):
         return data
 
     @classmethod
-    def from_dict(cl, data):
+    def from_dict(cls, data):
         """Create a message from a dictionary.
 
         Only "type" is required. The other will be set to default
         values.
         """
-        return cl(**data)
+        return cls(**data)
 
     def _get_value_names(self):
         # This is overriden by MetaMessage.

--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -10,11 +10,11 @@ TODO:
      - copy().
      - expose _key_signature_encode/decode?
 """
-from __future__ import print_function, division
 import math
 import struct
-from numbers import Integral
 from contextlib import contextmanager
+from numbers import Integral
+
 from ..messages import BaseMessage, check_time
 
 _charset = 'latin1'

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -15,19 +15,17 @@ http://www.recordingblogs.com/sa/tabid/82/EntryId/44/MIDI-Part-XIII-Delta-time-a
 http://www.sonicspot.com/guide/midifiles.html
 """
 
-from __future__ import print_function, division
 import io
-import time
 import string
 import struct
+import time
 from numbers import Integral
 
-from ..messages import Message, SPEC_BY_STATUS
 from .meta import (MetaMessage, build_meta_message, meta_charset,
                    encode_variable_int)
-
 from .tracks import MidiTrack, merge_tracks, fix_end_of_track
 from .units import tick2second
+from ..messages import Message, SPEC_BY_STATUS
 
 # The default tempo is 120 BPM.
 # (500000 microseconds per beat (quarter note).)
@@ -54,11 +52,6 @@ class DebugFileWrapper(object):
         data = self.file.read(size)
 
         for byte in data:
-            # Iterating gives us byte strings instead of ints in
-            # Python 2.
-            if isinstance(byte, str):
-                byte = ord(byte)
-
             print_byte(byte, self.file.tell())
 
         return data

--- a/mido/parser.py
+++ b/mido/parser.py
@@ -5,6 +5,7 @@ There is no need to use this module directly. All you need is
 available in the top level module.
 """
 from collections import deque
+
 from .messages import Message
 from .tokenizer import Tokenizer
 
@@ -41,7 +42,6 @@ class Parser(object):
             [for i in range(256)]
             (for i in range(256)]
             bytearray()
-            b''  # Will be converted to integers in Python 2.
         """
         self._tok.feed(data)
         self._decode()

--- a/mido/ports.py
+++ b/mido/ports.py
@@ -1,12 +1,12 @@
 """
 Useful tools for working with ports
 """
-from __future__ import unicode_literals
+import random
 import threading
 import time
-import random
-from .parser import Parser
+
 from .messages import Message
+from .parser import Parser
 
 # How many seconds to sleep before polling again.
 _DEFAULT_SLEEP_TIME = 0.001

--- a/mido/syx.py
+++ b/mido/syx.py
@@ -1,8 +1,8 @@
 """
 Read and write SYX file format
 """
-from __future__ import print_function
 import re
+
 from .parser import Parser
 
 
@@ -25,9 +25,7 @@ def read_syx_file(filename):
 
     parser = Parser()
 
-    # data[0] will give a byte string in Python 2 and an integer in
-    # Python 3.
-    if data[0] in (b'\xf0', 240):
+    if data[0] == 240:
         # Binary format.
         parser.feed(data)
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
-
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -18,7 +17,6 @@ def get_about():
 
 about = get_about()
 
-
 try:
     from setuptools import setup
 except ImportError:
@@ -31,7 +29,6 @@ if sys.argv[-1] == "publish":
 elif sys.argv[-1] == "docs":
     os.system("sphinx-build docs docs/_build")
     sys.exit()
-
 
 setup(
     name='mido',

--- a/tests/messages/test_strings.py
+++ b/tests/messages/test_strings.py
@@ -1,4 +1,5 @@
 from pytest import raises
+
 from mido.messages import Message
 
 
@@ -16,9 +17,3 @@ def test_encode_sysex():
     # This should not have an extra comma.
     assert str(Message('sysex', data=(1,))) == 'sysex data=(1) time=0'
     assert str(Message('sysex', data=(1, 2, 3))) == 'sysex data=(1,2,3) time=0'
-
-
-def test_encode_long_int():
-    # Make sure Python 2 doesn't stick an 'L' at the end of a long
-    # integer.
-    assert 'L' not in str(Message('clock', time=1231421984983298432948))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
 import random
+
 from pytest import raises
 
 from mido.messages import Message, specs


### PR DESCRIPTION
- Removed a no longer required statement
- Removed __future__ imports
- Updated shebangs to explicitly require python3
- Updated documentation samples to explicitly call python3
- Used standard syntax for @classmethod parameter
- Removed useless test in Python 3