### PR TITLE
Fix PortMidi backend

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,6 @@
 ignore = F401, C901, F901
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max-complexity = 10
+per-file-ignores =
+    # We really need to use an `import *` here to stop confusing everyone.
+    mido/backends/portmidi_init.py:F403, F405

--- a/mido/backends/portmidi_init.py
+++ b/mido/backends/portmidi_init.py
@@ -5,9 +5,7 @@ Copied straight from Grant Yoshida's portmidizero, with slight
 modifications.
 """
 import sys
-from ctypes import (CDLL, CFUNCTYPE, POINTER, Structure, c_char_p,
-                    c_int, c_long, c_uint, c_void_p, cast,
-                    create_string_buffer)
+from ctypes import *
 import ctypes.util
 
 dll_name = ''

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[],
     extras_require={
         'dev': ['check-manifest>=0.35',
-                'flake8>=3.4.1',
+                'flake8>=3.7.0',
                 'pytest>=3.2.2',
                 'sphinx>=1.6.3',
                 ],


### PR DESCRIPTION
Hopefully for good this time using the library recommended method of importing everything.

This issue has already crept up several times:
- d051be32e4f6ee52f4570bcfed445aae20a92526
- bdc924960160e2677dd196953d622c89b58cbc5d
- #120
- #383

Probably because the `byref` import was marked unused by IDEs and linters.

Fixes #372
Closes #383