### PR TITLE
Specify Python version explicitly for running pip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install the package
-      run: pip install -q -e .[dev]
+      run: python3 -m pip install --quiet --editable .[dev]
     - name: Run tests
       run: |
         pytest . -rs -q

--- a/README.rst
+++ b/README.rst
@@ -89,11 +89,11 @@ Installing
 
 ::
 
-    pip install mido
+    python3 -m pip install mido
 
 If you want to use ports::
 
-   pip install python-rtmidi
+   python3 -m pip install python-rtmidi
 
 See ``docs/backends/`` for other backends.
 

--- a/docs/backends/rtmidi_python.rst
+++ b/docs/backends/rtmidi_python.rst
@@ -9,7 +9,7 @@ Installing
 
 ::
 
-    pip install rtmidi-python
+    python3 - m pip install rtmidi-python
 
 
 Features

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -15,7 +15,7 @@ Installing for developers
 
 To install the dev dependencies, you can run the command::
 
-    pip install -e .[dev]
+    python3 -m pip install --editable .[dev]
 
 This will install all needed dependencies for testing and documentation.
 
@@ -28,8 +28,8 @@ are found in `mido/test_*.py`.
 
 Tests can be run using the command::
 
-    pip install -q -e .[dev]
-    pytest . -rs -q
+    python3 -m pip install --quiet --editable .[dev]
+    pytest -rs -q .
 
 This is also run automatically at every push to the `main` branch and
 at every pull request, as part of the GitHub Actions workflow.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -22,11 +22,11 @@ Installing
 
 To install::
 
-    pip install mido
+    python3 -m pip install mido
 
 If you want to use ports::
 
-    pip install python-rtmidi
+    python3 -m pip install python-rtmidi
 
 See :doc:`backends/index` for installation instructions for other
 backends.


### PR DESCRIPTION
The pip executable could point to any installed version of Python.
Specifying the Python interpreter avoids installing to the wrong version.

Related to #263