### PR TITLE
draft code of conduct

### DIFF
--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -1,3 +1,8 @@
+.. SPDX-FileCopyrightText: 2023 Mido project
+..
+.. SPDX-License-Identifier: CC-BY-SA-3.0
+
+
 Code of Conduct
 ===============
 
@@ -10,7 +15,7 @@ respectful**. Behaviours that reinforce these values contribute to a
 positive environment, and include:
 
 -  **Being open.** Members of the community are open to collaboration,
-   whether it’s on PEPs, patches, problems, or otherwise.
+   whether it’s on patches, problems, or otherwise.
 -  **Focusing on what is best for the community.** We’re respectful of
    the processes set forth in the community, and we work within them.
 -  **Acknowledging time and effort.** We’re respectful of the volunteer
@@ -84,7 +89,7 @@ Consequences
 ------------
 
 If a participant engages in behavior that violates this code of conduct,
-the Python community Code of Conduct team may take any action they deem
+the Mido project maintainers may take any action they deem
 appropriate, including warning the offender or expulsion from the
 community.
 
@@ -100,10 +105,9 @@ This Code of Conduct applies to the following online spaces:
 -  Code repositories, issue trackers, and pull requests made against
    the Mido GitHub organization.
 -  Discussions in the Mido GitHub organization.
--  The Mido mailing list.
 
-This Code of Conduct applies to the following people in official Python
-Software Foundation online spaces:
+This Code of Conduct applies to the following people in the Mido project
+online spaces:
 
 -  admins of the online space
 -  maintainers

--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -112,12 +112,23 @@ Software Foundation online spaces:
 -  all community members
 
 
-Procedure for Handling Incidents
---------------------------------
+Contact and Procedure for Handling Incidents
+--------------------------------------------
 
-.. warning::
-  We need a lightweight but well-defined procedure and contact
-  information for handling incidents. This is currently not yet in place.
+Please mention "@mido" in the issue or discussion or open a new issue
+on https://github.com/mido/mido and tag the organization admins using "@mido".
+
+You can also contact one or several organization admins directly:
+- radovan.bast@uit.no
+- ombdalen@gmail.com
+- raphael@doursenaud.fr
+
+We will then immediately discuss with the problematic user and convey why their
+behavior was inappropriate. We will also explain what the user can do to
+improve their behavior in the future. We will also explain that if the user
+continues to behave inappropriately, they will be banned from the community.
+Depending on the severity of the violation, we may also ban the user
+immediately.
 
 
 License

--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -1,0 +1,145 @@
+Code of Conduct
+===============
+
+
+Our Community
+-------------
+
+Members of the Mido community are **open, considerate, and
+respectful**. Behaviours that reinforce these values contribute to a
+positive environment, and include:
+
+-  **Being open.** Members of the community are open to collaboration,
+   whether it’s on PEPs, patches, problems, or otherwise.
+-  **Focusing on what is best for the community.** We’re respectful of
+   the processes set forth in the community, and we work within them.
+-  **Acknowledging time and effort.** We’re respectful of the volunteer
+   efforts that permeate the Mido community. We’re thoughtful when
+   addressing the efforts of others, keeping in mind that often times
+   the labor was completed simply for the good of the community.
+-  **Being respectful of differing viewpoints and experiences.** We’re
+   receptive to constructive comments and criticism, as the experiences
+   and skill sets of other members contribute to the whole of our
+   efforts.
+-  **Showing empathy towards other community members.** We’re attentive
+   in our communications, whether in person or online, and we’re tactful
+   when approaching differing views.
+-  **Being considerate.** Members of the community are considerate of
+   their peers – other Mido users.
+-  **Being respectful.** We’re respectful of others, their positions,
+   their skills, their commitments, and their efforts.
+-  **Gracefully accepting constructive criticism.** When we disagree, we
+   are courteous in raising our issues.
+-  **Using welcoming and inclusive language.** We’re accepting of all
+   who wish to take part in our activities, fostering an environment
+   where anyone can participate and everyone can make a difference.
+
+
+Our Standards
+-------------
+
+Every member of our community has the right to have their identity
+respected. The Mido community is dedicated to providing a positive
+experience for everyone, regardless of age, gender identity and
+expression, sexual orientation, disability, physical appearance, body
+size, ethnicity, nationality, race, or religion (or lack thereof),
+education, or socio-economic status.
+
+**Examples of unacceptable behavior** by participants include:
+
+-  Harassment of any participants in any form
+-  Deliberate intimidation, stalking, or following
+-  Logging or taking screenshots of online activity for harassment
+   purposes
+-  Publishing others’ private information, such as a physical or
+   electronic address, without explicit permission
+-  Violent threats or language directed against another person
+-  Incitement of violence or harassment towards any individual,
+   including encouraging a person to commit suicide or to engage in
+   self-harm
+-  Creating additional online accounts in order to harass another person
+   or circumvent a ban
+-  Sexual language and imagery in online communities or in any
+   conference venue, including talks
+-  Insults, put downs, or jokes that are based upon stereotypes, that
+   are exclusionary, or that hold others up for ridicule
+-  Excessive swearing
+-  Unwelcome sexual attention or advances
+-  Unwelcome physical contact, including simulated physical contact (eg,
+   textual descriptions like “hug” or “backrub”) without consent or
+   after a request to stop
+-  Pattern of inappropriate social contact, such as requesting/assuming
+   inappropriate levels of intimacy with others
+-  Sustained disruption of online community discussions, in-person
+   presentations, or other in-person events
+-  Continued one-on-one communication after requests to cease
+-  Other conduct that is inappropriate for a professional audience
+   including people of many different backgrounds
+
+Community members asked to stop any inappropriate behavior are expected
+to comply immediately.
+
+
+Consequences
+------------
+
+If a participant engages in behavior that violates this code of conduct,
+the Python community Code of Conduct team may take any action they deem
+appropriate, including warning the offender or expulsion from the
+community.
+
+Thank you for helping make this a welcoming, friendly community for
+everyone.
+
+
+Scope
+-----
+
+This Code of Conduct applies to the following online spaces:
+
+-  Code repositories, issue trackers, and pull requests made against
+   the Mido GitHub organization.
+-  Discussions in the Mido GitHub organization.
+-  The Mido mailing list.
+
+This Code of Conduct applies to the following people in official Python
+Software Foundation online spaces:
+
+-  admins of the online space
+-  maintainers
+-  reviewers
+-  contributors
+-  all community members
+
+
+Procedure for Handling Incidents
+--------------------------------
+
+.. warning::
+  We need a lightweight but well-defined procedure and contact
+  information for handling incidents. This is currently not yet in place.
+
+
+License
+-------
+
+This Code of Conduct is licensed under the `Creative Commons
+Attribution-ShareAlike 3.0 Unported
+License <https://creativecommons.org/licenses/by-sa/3.0/>`__.
+
+|Creative Commons License|
+
+
+Attributions
+------------
+
+This Code of Conduct was adapted from
+the `PSF Code of Conduct <https://www.python.org/psf/codeofconduct/>`__, which
+was forked from the example policy from the `Geek
+Feminism wiki, created by the Ada Initiative and other
+volunteers <http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy>`__,
+which is under a `Creative Commons Zero
+license <https://creativecommons.org/publicdomain/zero/1.0/>`__.
+
+.. |Creative Commons License| image:: https://licensebuttons.net/l/by-sa/3.0/88x31.png
+   :target: http://creativecommons.org/licenses/by-sa/3.0/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,7 @@ Contents
    installing
    backends/index
    contributing
+   code-of-conduct
    intro
    messages
    frozen_messages


### PR DESCRIPTION
- missing: contact information and procedure for handling incidents (search for "warning" for text we need to adapt before merging)

- part of #270