### PR TITLE
move complex function out of __iter__() first loop

### DIFF
--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -315,6 +315,9 @@ class MidiFile:
         elif self.filename is not None:
             with open(filename, 'rb') as file:
                 self._load(file)
+        
+        if self.type != 2:
+            self.merged_track = merge_tracks(self.tracks)
 
     def add_track(self, name=None):
         """Add a new track to the file.
@@ -326,6 +329,8 @@ class MidiFile:
         if name is not None:
             track.name = name
         self.tracks.append(track)
+        if self.type != 2:
+            self.merged_track = merge_tracks(self.tracks)
         return track
 
     def _load(self, infile):
@@ -374,7 +379,7 @@ class MidiFile:
             raise TypeError("can't merge tracks in type 2 (asynchronous) file")
 
         tempo = DEFAULT_TEMPO
-        for msg in merge_tracks(self.tracks):
+        for msg in self.merged_track:
             # Convert message time from absolute time
             # in ticks to relative time in seconds.
             if msg.time > 0:

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -315,7 +315,7 @@ class MidiFile:
         elif self.filename is not None:
             with open(filename, 'rb') as file:
                 self._load(file)
-        
+        # merge tracks at load time to prevent timing error on first call to __iter__()
         if self.type != 2:
             self.merged_track = merge_tracks(self.tracks)
 
@@ -329,6 +329,7 @@ class MidiFile:
         if name is not None:
             track.name = name
         self.tracks.append(track)
+        # merge new track immediately to prevent timing error on first call to __iter__()
         if self.type != 2:
             self.merged_track = merge_tracks(self.tracks)
         return track

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -315,7 +315,8 @@ class MidiFile:
         elif self.filename is not None:
             with open(filename, 'rb') as file:
                 self._load(file)
-        # merge tracks at load time to prevent timing error on first call to __iter__()
+        # merge tracks at load time to prevent timing error on 
+        # first call to __iter__()
         if self.type != 2:
             self.merged_track = merge_tracks(self.tracks)
 
@@ -329,7 +330,8 @@ class MidiFile:
         if name is not None:
             track.name = name
         self.tracks.append(track)
-        # merge new track immediately to prevent timing error on first call to __iter__()
+        # merge new track immediately to prevent timing error on 
+        # first call to __iter__()
         if self.type != 2:
             self.merged_track = merge_tracks(self.tracks)
         return track

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -315,7 +315,7 @@ class MidiFile:
         elif self.filename is not None:
             with open(filename, 'rb') as file:
                 self._load(file)
-        # merge tracks at load time to prevent timing error on 
+        # merge tracks at load time to prevent timing error on
         # first call to __iter__()
         if self.type != 2:
             self.merged_track = merge_tracks(self.tracks)
@@ -330,7 +330,7 @@ class MidiFile:
         if name is not None:
             track.name = name
         self.tracks.append(track)
-        # merge new track immediately to prevent timing error on 
+        # merge new track immediately to prevent timing error on
         # first call to __iter__()
         if self.type != 2:
             self.merged_track = merge_tracks(self.tracks)


### PR DESCRIPTION
The MidiFile.iter() function calls merge_tracks() on its first iteration. I have examples of this function taking many tenths of seconds to execute. This causes issues when using Midifile.play() to provide the timing for midi playback, as the first note(s) will play long after their calculated 'input_time' (because they have to wait on merge_tracks()).

This change calls merge_tracks on MidiFile instantiation and after each add_track() call, removing the need to call it in MidiFile.iter()