### PR TITLE
Faster merge tracks

### DIFF
--- a/mido/messages/messages.py
+++ b/mido/messages/messages.py
@@ -118,14 +118,14 @@ class Message(BaseMessage):
         check_msgdict(msgdict)
         vars(self).update(msgdict)
 
-    def copy(self, **overrides):
+    def copy(self, skip_checks=False, **overrides):
         """Return a copy of the message.
 
         Attributes will be overridden by the passed keyword arguments.
         Only message specific attributes can be overridden. The message
         type can not be changed.
         """
-        if not overrides:
+        if skip_checks or not overrides:
             # Bypass all checks.
             msg = self.__class__.__new__(self.__class__)
             vars(msg).update(vars(self))

--- a/mido/messages/messages.py
+++ b/mido/messages/messages.py
@@ -127,6 +127,9 @@ class Message(BaseMessage):
         Attributes will be overridden by the passed keyword arguments.
         Only message specific attributes can be overridden. The message
         type can not be changed.
+
+        The skip_checks arg can be used to bypass validation of message
+        attributes and should be used cautiously.
         """
         if not overrides:
             # Bypass all checks.

--- a/mido/messages/messages.py
+++ b/mido/messages/messages.py
@@ -111,11 +111,14 @@ class SysexData(tuple):
 
 
 class Message(BaseMessage):
-    def __init__(self, type, **args):
+    def __init__(self, type, skip_checks=False, **args):
         msgdict = make_msgdict(type, args)
         if type == 'sysex':
             msgdict['data'] = SysexData(msgdict['data'])
-        check_msgdict(msgdict)
+
+        if not skip_checks:
+            check_msgdict(msgdict)
+
         vars(self).update(msgdict)
 
     def copy(self, skip_checks=False, **overrides):
@@ -125,7 +128,7 @@ class Message(BaseMessage):
         Only message specific attributes can be overridden. The message
         type can not be changed.
         """
-        if skip_checks or not overrides:
+        if not overrides:
             # Bypass all checks.
             msg = self.__class__.__new__(self.__class__)
             vars(msg).update(vars(self))
@@ -139,8 +142,11 @@ class Message(BaseMessage):
 
         msgdict = vars(self).copy()
         msgdict.update(overrides)
-        check_msgdict(msgdict)
-        return self.__class__(**msgdict)
+
+        if not skip_checks:
+            check_msgdict(msgdict)
+
+        return self.__class__(skip_checks=skip_checks, **msgdict)
 
     @classmethod
     def from_bytes(cl, data, time=0):

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -396,7 +396,7 @@ class MidiFile:
             else:
                 delta = 0
 
-            yield msg.copy(time=delta)
+            yield msg.copy(skip_checks=True, time=delta)
 
             if msg.type == 'set_tempo':
                 tempo = msg.tempo

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -327,7 +327,7 @@ class MidiFile:
             raise TypeError("can't merge tracks in type 2 (asynchronous) file")
 
         if self._merged_track is None:
-            self._merged_track = merge_tracks(self.tracks)
+            self._merged_track = merge_tracks(self.tracks, skip_checks=True)
         return self._merged_track
 
     @merged_track.deleter

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -109,9 +109,9 @@ def merge_tracks(tracks, skip_checks=False):
     The messages are returned in playback order with delta times
     as if they were all in one track.
 
-    By default, assumes the messages in tracks have already been
-    validated by mido.checks. Pass skip_checks=False if you need to
-    validate the  messages before merging.
+    Pass skip_checks=True to skip validation of messages before merging.
+    This should ONLY be used when the messages in tracks have already
+    been validated by mido.checks.
     """
     messages = []
     for track in tracks:

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -64,7 +64,7 @@ class MidiTrack(list):
         return f'{self.__class__.__name__}({messages})'
 
 
-def _to_abstime(messages, skip_checks=True):
+def _to_abstime(messages, skip_checks=False):
     """Convert messages to absolute time."""
     now = 0
     for msg in messages:
@@ -72,7 +72,7 @@ def _to_abstime(messages, skip_checks=True):
         yield msg.copy(skip_checks=skip_checks, time=now)
 
 
-def _to_reltime(messages, skip_checks=True):
+def _to_reltime(messages, skip_checks=False):
     """Convert messages to relative time."""
     now = 0
     for msg in messages:
@@ -81,7 +81,7 @@ def _to_reltime(messages, skip_checks=True):
         now = msg.time
 
 
-def fix_end_of_track(messages, skip_checks=True):
+def fix_end_of_track(messages, skip_checks=False):
     """Remove all end_of_track messages and add one at the end.
 
     This is used by merge_tracks() and MidiFile.save()."""
@@ -103,7 +103,7 @@ def fix_end_of_track(messages, skip_checks=True):
     yield MetaMessage('end_of_track', time=accum)
 
 
-def merge_tracks(tracks, skip_checks=True):
+def merge_tracks(tracks, skip_checks=False):
     """Returns a MidiTrack object with all messages from all tracks.
 
     The messages are returned in playback order with delta times

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -64,24 +64,24 @@ class MidiTrack(list):
         return f'{self.__class__.__name__}({messages})'
 
 
-def _to_abstime(messages):
+def _to_abstime(messages, skip_checks=True):
     """Convert messages to absolute time."""
     now = 0
     for msg in messages:
         now += msg.time
-        yield msg.copy(time=now)
+        yield msg.copy(skip_checks=skip_checks, time=now)
 
 
-def _to_reltime(messages):
+def _to_reltime(messages, skip_checks=True):
     """Convert messages to relative time."""
     now = 0
     for msg in messages:
         delta = msg.time - now
-        yield msg.copy(time=delta)
+        yield msg.copy(skip_checks=skip_checks, time=delta)
         now = msg.time
 
 
-def fix_end_of_track(messages):
+def fix_end_of_track(messages, skip_checks=True):
     """Remove all end_of_track messages and add one at the end.
 
     This is used by merge_tracks() and MidiFile.save()."""
@@ -95,7 +95,7 @@ def fix_end_of_track(messages):
         else:
             if accum:
                 delta = accum + msg.time
-                yield msg.copy(time=delta)
+                yield msg.copy(skip_checks=skip_checks, time=delta)
                 accum = 0
             else:
                 yield msg
@@ -103,16 +103,25 @@ def fix_end_of_track(messages):
     yield MetaMessage('end_of_track', time=accum)
 
 
-def merge_tracks(tracks):
+def merge_tracks(tracks, skip_checks=True):
     """Returns a MidiTrack object with all messages from all tracks.
 
     The messages are returned in playback order with delta times
     as if they were all in one track.
+
+    By default, assumes the messages in tracks have already been
+    validated by mido.checks. Pass skip_checks=False if you need to
+    validate the  messages before merging.
     """
     messages = []
     for track in tracks:
-        messages.extend(_to_abstime(track))
+        messages.extend(_to_abstime(track, skip_checks=skip_checks))
 
     messages.sort(key=lambda msg: msg.time)
 
-    return MidiTrack(fix_end_of_track(_to_reltime(messages)))
+    return MidiTrack(
+        fix_end_of_track(
+            _to_reltime(messages, skip_checks=skip_checks),
+            skip_checks=skip_checks,
+        )
+    )

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -40,12 +40,11 @@ def test_track_repr():
 
 def test_merge_large_midifile():
     mid = mido.MidiFile()
-    for k in range(4):
+    for k in range(5):
         t = mido.MidiTrack()
         for _ in range(10000):
-            msg = mido.Message("note_on", note=72, time=1000 + 100 * k)
-            msg = mido.Message("note_off", note=72, time=500 + 100 * k)
-            t.append(msg)
+            t.append(mido.Message("note_on", note=72, time=1000 + 100 * k))
+            t.append(mido.Message("note_off", note=72, time=500 + 100 * k))
         mid.tracks.append(t)
 
     start = time.time()
@@ -56,4 +55,4 @@ def test_merge_large_midifile():
     merged_duration_ticks = sum(msg.time for msg in merged)
     max_track_duration_ticks = max(sum(msg.time for msg in t) for t in mid.tracks)
     assert merged_duration_ticks == max_track_duration_ticks
-    assert (finish - start) < 0.1
+    assert (finish - start) < 0.5

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -55,4 +55,4 @@ def test_merge_large_midifile():
     max_track_duration_ticks = max(
         sum(msg.time for msg in t) for t in mid.tracks)
     assert merged_duration_ticks == max_track_duration_ticks
-    assert (finish - start) < 0.5
+    assert (finish - start) < 1.0

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 import itertools
-
+import mido
+import time
 from mido.messages import Message
 from mido.midifiles.meta import MetaMessage
 from mido.midifiles.tracks import MidiTrack
@@ -35,3 +36,22 @@ def test_track_repr():
     track_eval = eval(repr(track))
     for m1, m2 in zip(track, track_eval):
         assert m1 == m2
+
+
+def test_merge_large_midifile():
+    mid = mido.MidiFile()
+    for k in range(4):
+        t = mido.MidiTrack()
+        for _ in range(10000):
+            msg = mido.Message("note_on", note=72, time=1000 + 100 * k)
+            msg = mido.Message("note_off", note=72, time=500 + 100 * k)
+            t.append(msg)
+        mid.tracks.append(t)
+
+    start = time.time()
+    i = 0
+    for _ in mido.merge_tracks(mid.tracks):
+        i += 1
+    finish = time.time()
+
+    assert (finish - start) < 0.1

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -48,11 +48,11 @@ def test_merge_large_midifile():
         mid.tracks.append(t)
 
     start = time.time()
-    i = 0
     merged = list(mido.merge_tracks(mid.tracks, skip_checks=True))
     finish = time.time()
 
     merged_duration_ticks = sum(msg.time for msg in merged)
-    max_track_duration_ticks = max(sum(msg.time for msg in t) for t in mid.tracks)
+    max_track_duration_ticks = max(
+        sum(msg.time for msg in t) for t in mid.tracks)
     assert merged_duration_ticks == max_track_duration_ticks
     assert (finish - start) < 0.5

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 import itertools
-import mido
 import time
+
+import mido
 from mido.messages import Message
 from mido.midifiles.meta import MetaMessage
 from mido.midifiles.tracks import MidiTrack

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -50,8 +50,10 @@ def test_merge_large_midifile():
 
     start = time.time()
     i = 0
-    for _ in mido.merge_tracks(mid.tracks):
-        i += 1
+    merged = list(mido.merge_tracks(mid.tracks, skip_checks=True))
     finish = time.time()
 
+    merged_duration_ticks = sum(msg.time for msg in merged)
+    max_track_duration_ticks = max(sum(msg.time for msg in t) for t in mid.tracks)
+    assert merged_duration_ticks == max_track_duration_ticks
     assert (finish - start) < 0.1

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -56,4 +56,4 @@ def test_merge_large_midifile():
     max_track_duration_ticks = max(
         sum(msg.time for msg in t) for t in mid.tracks)
     assert merged_duration_ticks == max_track_duration_ticks
-    assert (finish - start) < 1.0
+    assert (finish - start) < 2.0


### PR DESCRIPTION
Closes #472 

Small and low priority performance enhancement to `mido.merge_tracks`. Skip redundant data checks. When you have a `MidiFile` that you want to iterate over, its messages should already have passed `mido.checks`. 

I made `merge_tracks` skip the checks by default, but since it is exposed to clients, maybe it should continue existing behavior by default and only change for internal invocations (like iterating over a `MidiFile`).