### PR TITLE
Don't use star imports in portmidi_init

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,3 @@
 ignore = F401, C901, F901
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max-complexity = 10
-per-file-ignores =
-    # We really need to use an `import *` here to stop confusing everyone.
-    mido/backends/portmidi_init.py:F403, F405

--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -7,6 +7,7 @@ available in the toplevel module.
 PortMidi documentation:
 http://portmedia.sourceforge.net/portmidi/doxygen/
 """
+import ctypes
 import threading
 from ..ports import BaseInput, BaseOutput, sleep
 from . import portmidi_init as pm
@@ -121,7 +122,7 @@ class PortCommon:
 
         if self.is_input:
             _check_error(pm.lib.Pm_OpenInput(
-                         pm.byref(self._stream),
+                         ctypes.byref(self._stream),
                          device['id'],  # Input device
                          pm.null,       # Input driver info
                          1000,          # Buffer size
@@ -129,7 +130,7 @@ class PortCommon:
                          pm.null))      # Time info
         else:
             _check_error(pm.lib.Pm_OpenOutput(
-                         pm.byref(self._stream),
+                         ctypes.byref(self._stream),
                          device['id'],  # Output device
                          pm.null,       # Output diver info
                          0,             # Buffer size

--- a/mido/backends/portmidi_init.py
+++ b/mido/backends/portmidi_init.py
@@ -5,7 +5,7 @@ Copied straight from Grant Yoshida's portmidizero, with slight
 modifications.
 """
 import sys
-from ctypes import *
+import ctypes
 import ctypes.util
 
 dll_name = ''
@@ -16,7 +16,7 @@ elif sys.platform in ('win32', 'cygwin'):
 else:
     dll_name = 'libportmidi.so'
 
-lib = CDLL(dll_name)
+lib = ctypes.CDLL(dll_name)
 
 null = None
 false = 0
@@ -30,12 +30,12 @@ PM_HOST_ERROR_MSG_LEN = 256
 
 def get_host_error_message():
     """Return host error message."""
-    buf = create_string_buffer(PM_HOST_ERROR_MSG_LEN)
+    buf = ctypes.create_string_buffer(PM_HOST_ERROR_MSG_LEN)
     lib.Pm_GetHostErrorText(buf, PM_HOST_ERROR_MSG_LEN)
     return buf.raw.decode().rstrip('\0')
 
 
-PmError = c_int
+PmError = ctypes.c_int
 # PmError enum
 pmNoError = 0
 pmHostError = -10000
@@ -51,41 +51,41 @@ pmBufferMaxSize = -9992
 lib.Pm_Initialize.restype = PmError
 lib.Pm_Terminate.restype = PmError
 
-PmDeviceID = c_int
+PmDeviceID = ctypes.c_int
 
-PortMidiStreamPtr = c_void_p
+PortMidiStreamPtr = ctypes.c_void_p
 PmStreamPtr = PortMidiStreamPtr
-PortMidiStreamPtrPtr = POINTER(PortMidiStreamPtr)
+PortMidiStreamPtrPtr = ctypes.POINTER(PortMidiStreamPtr)
 
-lib.Pm_HasHostError.restype = c_int
+lib.Pm_HasHostError.restype = ctypes.c_int
 lib.Pm_HasHostError.argtypes = [PortMidiStreamPtr]
 
-lib.Pm_GetErrorText.restype = c_char_p
+lib.Pm_GetErrorText.restype = ctypes.c_char_p
 lib.Pm_GetErrorText.argtypes = [PmError]
 
-lib.Pm_GetHostErrorText.argtypes = [c_char_p, c_uint]
+lib.Pm_GetHostErrorText.argtypes = [ctypes.c_char_p, ctypes.c_uint]
 
 pmNoDevice = -1
 
 
-class PmDeviceInfo(Structure):
-    _fields_ = [("structVersion", c_int),
-                ("interface", c_char_p),
-                ("name", c_char_p),
-                ("is_input", c_int),
-                ("is_output", c_int),
-                ("opened", c_int)]
+class PmDeviceInfo(ctypes.Structure):
+    _fields_ = [("structVersion", ctypes.c_int),
+                ("interface", ctypes.c_char_p),
+                ("name", ctypes.c_char_p),
+                ("is_input", ctypes.c_int),
+                ("is_output", ctypes.c_int),
+                ("opened", ctypes.c_int)]
 
 
-PmDeviceInfoPtr = POINTER(PmDeviceInfo)
+PmDeviceInfoPtr = ctypes.POINTER(PmDeviceInfo)
 
-lib.Pm_CountDevices.restype = c_int
+lib.Pm_CountDevices.restype = ctypes.c_int
 lib.Pm_GetDefaultOutputDeviceID.restype = PmDeviceID
 lib.Pm_GetDefaultInputDeviceID.restype = PmDeviceID
 
-PmTimestamp = c_long
-PmTimeProcPtr = CFUNCTYPE(PmTimestamp, c_void_p)
-NullTimeProcPtr = cast(null, PmTimeProcPtr)
+PmTimestamp = ctypes.c_long
+PmTimeProcPtr = ctypes.CFUNCTYPE(PmTimestamp, ctypes.c_void_p)
+NullTimeProcPtr = ctypes.cast(null, PmTimeProcPtr)
 
 # PmBefore is not defined
 
@@ -95,25 +95,25 @@ lib.Pm_GetDeviceInfo.restype = PmDeviceInfoPtr
 lib.Pm_OpenInput.restype = PmError
 lib.Pm_OpenInput.argtypes = [PortMidiStreamPtrPtr,
                              PmDeviceID,
-                             c_void_p,
-                             c_long,
+                             ctypes.c_void_p,
+                             ctypes.c_long,
                              PmTimeProcPtr,
-                             c_void_p]
+                             ctypes.c_void_p]
 
 lib.Pm_OpenOutput.restype = PmError
 lib.Pm_OpenOutput.argtypes = [PortMidiStreamPtrPtr,
                               PmDeviceID,
-                              c_void_p,
-                              c_long,
+                              ctypes.c_void_p,
+                              ctypes.c_long,
                               PmTimeProcPtr,
-                              c_void_p,
-                              c_long]
+                              ctypes.c_void_p,
+                              ctypes.c_long]
 
 lib.Pm_SetFilter.restype = PmError
-lib.Pm_SetFilter.argtypes = [PortMidiStreamPtr, c_long]
+lib.Pm_SetFilter.argtypes = [PortMidiStreamPtr, ctypes.c_long]
 
 lib.Pm_SetChannelMask.restype = PmError
-lib.Pm_SetChannelMask.argtypes = [PortMidiStreamPtr, c_int]
+lib.Pm_SetChannelMask.argtypes = [PortMidiStreamPtr, ctypes.c_int]
 
 lib.Pm_Abort.restype = PmError
 lib.Pm_Abort.argtypes = [PortMidiStreamPtr]
@@ -121,47 +121,47 @@ lib.Pm_Abort.argtypes = [PortMidiStreamPtr]
 lib.Pm_Close.restype = PmError
 lib.Pm_Close.argtypes = [PortMidiStreamPtr]
 
-PmMessage = c_long
+PmMessage = ctypes.c_long
 
 
-class PmEvent(Structure):
+class PmEvent(ctypes.Structure):
     _fields_ = [("message", PmMessage),
                 ("timestamp", PmTimestamp)]
 
 
-PmEventPtr = POINTER(PmEvent)
+PmEventPtr = ctypes.POINTER(PmEvent)
 
 lib.Pm_Read.restype = PmError
-lib.Pm_Read.argtypes = [PortMidiStreamPtr, PmEventPtr, c_long]
+lib.Pm_Read.argtypes = [PortMidiStreamPtr, PmEventPtr, ctypes.c_long]
 
 lib.Pm_Poll.restype = PmError
 lib.Pm_Poll.argtypes = [PortMidiStreamPtr]
 
 lib.Pm_Write.restype = PmError
-lib.Pm_Write.argtypes = [PortMidiStreamPtr, PmEventPtr, c_long]
+lib.Pm_Write.argtypes = [PortMidiStreamPtr, PmEventPtr, ctypes.c_long]
 
 lib.Pm_WriteShort.restype = PmError
-lib.Pm_WriteShort.argtypes = [PortMidiStreamPtr, PmTimestamp, c_long]
+lib.Pm_WriteShort.argtypes = [PortMidiStreamPtr, PmTimestamp, ctypes.c_long]
 
 lib.Pm_WriteSysEx.restype = PmError
-lib.Pm_WriteSysEx.argtypes = [PortMidiStreamPtr, PmTimestamp, c_char_p]
+lib.Pm_WriteSysEx.argtypes = [PortMidiStreamPtr, PmTimestamp, ctypes.c_char_p]
 
 # porttime.h
 
 # PtError enum
-PtError = c_int
+PtError = ctypes.c_int
 ptNoError = 0
 ptHostError = -10000
 ptAlreadyStarted = -9999
 ptAlreadyStopped = -9998
 ptInsufficientMemory = -9997
 
-PtTimestamp = c_long
-PtCallback = CFUNCTYPE(PmTimestamp, c_void_p)
+PtTimestamp = ctypes.c_long
+PtCallback = ctypes.CFUNCTYPE(PmTimestamp, ctypes.c_void_p)
 
 lib.Pt_Start.restype = PtError
-lib.Pt_Start.argtypes = [c_int, PtCallback, c_void_p]
+lib.Pt_Start.argtypes = [ctypes.c_int, PtCallback, ctypes.c_void_p]
 
 lib.Pt_Stop.restype = PtError
-lib.Pt_Started.restype = c_int
+lib.Pt_Started.restype = ctypes.c_int
 lib.Pt_Time.restype = PtTimestamp


### PR DESCRIPTION
Follows up on #413.

Instead of using star imports, let's just be specific about what we're using from `ctypes` and that's that 😄 