### PR TITLE
Release automation prototype

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ permissions:
     contents: write
 
 jobs:
-  build:
+  build-github-pages:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +27,7 @@ jobs:
           python-version-file: 'pyproject.toml'
           cache: 'pip'
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido
         run: python3 -m pip install --quiet .[build-docs]
       - name: Sphinx build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2023 Raphaël Doursenaud <rdoursenaud@gmail.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# This workflow needs access to 2 GitHub secrets:
+#   - TEST_PYPI_TOKEN: The API token to deploy on https://test.pypi.org
+#   - PROD_PYPI_TOKEN: The API token to deploy on https://pypi.org
+#
+# Both API tokens shall be generated from a user account with appropriate
+# permissions on the target project and have their scope set to the project.
+#
+# The API tokens have then to be registered as secrets in the GitHub
+# repository's configuration under the names specified above.
+# See: https://docs.github.com/actions/security-guides/encrypted-secrets
+
+# TODO: Allow the publishing of pre-releases (a, b, rc).
+# The "Test installation" step requires a `--pre` argument to install
+# pre-releases.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: 'pyproject.toml'
+          cache: 'pip'
+      - name: Upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
+      - name: Install or upgrade build
+        run: python3 -m pip install --upgrade build
+      # Build dependencies are automatically installed from `pyproject.toml`.
+      - name: Build mido
+        run: python3 -m build
+      # Store build artifacts
+      - uses: actions/upload-artifact@v3
+        with:
+          name: mido-build
+          path: dist/
+
+  publish-test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Retrieve build artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          name: mido-build
+      - name: Check distribution name
+        run: twine check dist/*
+      - name: Publish to test.pypi.org
+        run: twine upload --repository testpypi dist/*
+        env:
+          TWINE_NON_INTERACTIVE: 1
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+      - name: Test installation
+        run: |
+          python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps mido
+      - name: Test importing package
+        run: python3 -c "import mido; print(mido.version_info)"
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish-test
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: mido-build
+      - name: Publish to pypi.org
+        run: twine upload dist/*
+        env:
+          TWINE_NON_INTERACTIVE: 1
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PROD_PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ on:
   workflow_dispatch:
 
 jobs:
+
   style:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
           python-version-file: 'pyproject.toml'
           cache: 'pip'
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido in dev mode
         run: python3 -m pip install --quiet .[lint-code]
       - name: Lint code with flake
@@ -34,7 +34,6 @@ jobs:
 
   reuse:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,7 +43,7 @@ jobs:
           python-version-file: 'pyproject.toml'
           cache: 'pip'
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido in dev mode
         run: python3 -m pip install --quiet .[lint-reuse]
       - name: Lint reuse
@@ -52,7 +51,6 @@ jobs:
 
   manifest:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,7 +60,7 @@ jobs:
           python-version-file: 'pyproject.toml'
           cache: 'pip'
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido in dev mode
         run: python3 -m pip install --quiet .[check-manifest]
       - name: Check manifest is complete
@@ -70,7 +68,6 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -80,7 +77,7 @@ jobs:
           python-version-file: 'pyproject.toml'
           cache: 'pip'
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido in dev mode
         run: python3 -m pip install --quiet .[build-docs]
       - name: Check documentation
@@ -93,7 +90,6 @@ jobs:
       - reuse
       - style
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os:
@@ -106,7 +102,6 @@ jobs:
             - '3.9'
             - '3.10'
             - '3.11'
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -116,7 +111,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Upgrade pip
-        run: python3 -m pip install --upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido in dev mode
         run: python3 -m pip install --quiet .[test-code]
       - name: Test with pytest

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -59,6 +59,12 @@ Glossary
     python
         The `Python programming language <https://www.python.org>`_.
 
+    rtd
+    read the docs
+        `Read the Docs <https://www.readthedocs.org>`_ or RTD for short
+        is a popular service to build, manage versions and host documentation
+        generated from Sphinx (and now MkDocs) in the Python ecosystem.
+
     rtpmidi
         A standard protocol to send MIDI over a TCP/IP link.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ mido-connect = "scripts.mido_connect:main"
 packages = [
     "mido",
     "mido.backends",
+    "mido.messages",
+    "mido.midifiles",
 ]
 include-package-data = true
 


### PR DESCRIPTION
Closes #498

@olemb I don't have enough permissions on PyPI to create the necessary token for the last step. Once this is merged and tested, please create one and put it in a GitHub secret named `PROD_PYPI_TOKEN` to enable the effectively releasing to pypi.org. Everything you need to know is in the `release.yml` file comments if need be.