### PR TITLE
fix portmidi backend sysex

### DIFF
--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -262,7 +262,7 @@ class Output(PortCommon, BaseOutput):
     def _send(self, message):
         if message.type == 'sysex':
             # Sysex messages are written as a string.
-            string = pm.c_char_p(bytes(message.bin()))
+            string = pm.ctypes.c_char_p(bytes(message.bin()))
             timestamp = 0  # Ignored when latency = 0
             _check_error(pm.lib.Pm_WriteSysEx(self._stream, timestamp, string))
         else:

--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -262,7 +262,7 @@ class Output(PortCommon, BaseOutput):
     def _send(self, message):
         if message.type == 'sysex':
             # Sysex messages are written as a string.
-            string = pm.ctypes.c_char_p(bytes(message.bin()))
+            string = ctypes.c_char_p(bytes(message.bin()))
             timestamp = 0  # Ignored when latency = 0
             _check_error(pm.lib.Pm_WriteSysEx(self._stream, timestamp, string))
         else:


### PR DESCRIPTION
Fix for error:
AttributeError: module 'mido.backends.portmidi_init' has no attribute 'c_char_p'
