### PR TITLE
Fix issue #530

### DIFF
--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -241,7 +241,7 @@ def write_track(outfile, track):
     data = bytearray()
 
     running_status_byte = None
-    for msg in fix_end_of_track(track, readonly_promise=True):
+    for msg in fix_end_of_track(track, safe=False):
         if not isinstance(msg.time, Integral):
             raise ValueError('message time must be int in MIDI file')
         if msg.time < 0:

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -241,7 +241,7 @@ def write_track(outfile, track):
     data = bytearray()
 
     running_status_byte = None
-    for msg in fix_end_of_track(track):
+    for msg in fix_end_of_track(track, readonly_promise=True):
         if not isinstance(msg.time, Integral):
             raise ValueError('message time must be int in MIDI file')
         if msg.time < 0:

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -81,18 +81,19 @@ def _to_reltime(messages):
         now = msg.time
 
 
-def fix_end_of_track(messages, *, readonly_promise=False):
+def fix_end_of_track(messages, *, safe=True):
     """Remove all `'end_of_track'` messages and add one at the end.
 
     This is used by `merge_tracks()` and `MidiFile.save()`.
-    
-    `readonly_promise=True` saves memory but yields a mix of original
+
+    `safe=False` saves memory but yields a mix of original
     and copied messages that is not intended for further modifications,
-    i.e. whose modifications will affect the original input in weird
-    ways. `MidiFile.save()` uses `readonly_promise=True` because it
+    because such modifications affect only incoherent parts of the
+    original input (namely the parts that could be reused in the output
+    to save memory). `MidiFile.save()` uses `safe=False` because it
     discards the data without modifying it. If you might modify the
     outputs of `fix_end_of_track()` or pass them on for modification
-    or are unsure, use the default `readonly_promise=False`."""
+    or are unsure, use the default `safe=True`."""
     # Accumulated delta time from removed end of track messages.
     # This is added to the next message.
     accum = 0
@@ -106,10 +107,10 @@ def fix_end_of_track(messages, *, readonly_promise=False):
                 yield msg.copy(time=delta)
                 accum = 0
             else:
-                if readonly_promise: # https://github.com/mido/mido/issues/530
-                    yield msg
-                else:
+                if safe:  # https://github.com/mido/mido/issues/530
                     yield msg.copy()
+                else:
+                    yield msg
 
     yield MetaMessage('end_of_track', time=accum)
 
@@ -126,4 +127,4 @@ def merge_tracks(tracks):
 
     messages.sort(key=lambda msg: msg.time)
 
-    return MidiTrack(fix_end_of_track(_to_reltime(messages), readonly_promise=False))
+    return MidiTrack(fix_end_of_track(_to_reltime(messages), safe=True))

--- a/mido/midifiles/tracks.py
+++ b/mido/midifiles/tracks.py
@@ -81,18 +81,18 @@ def _to_reltime(messages):
         now = msg.time
 
 
-def fix_end_of_track(messages, *, read_only_promise=False):
+def fix_end_of_track(messages, *, readonly_promise=False):
     """Remove all `'end_of_track'` messages and add one at the end.
 
     This is used by `merge_tracks()` and `MidiFile.save()`.
     
-    `read_only_promise=True` saves memory but yields a mix of original
+    `readonly_promise=True` saves memory but yields a mix of original
     and copied messages that is not intended for further modifications,
     i.e. whose modifications will affect the original input in weird
-    ways. `MidiFile.save()` uses `read_only_promise=True` because it
+    ways. `MidiFile.save()` uses `readonly_promise=True` because it
     discards the data without modifying it. If you might modify the
     outputs of `fix_end_of_track()` or pass them on for modification
-    or are unsure, use the default `read_only_promise=False`."""
+    or are unsure, use the default `readonly_promise=False`."""
     # Accumulated delta time from removed end of track messages.
     # This is added to the next message.
     accum = 0
@@ -106,7 +106,7 @@ def fix_end_of_track(messages, *, read_only_promise=False):
                 yield msg.copy(time=delta)
                 accum = 0
             else:
-                if read_only_promise: # https://github.com/mido/mido/issues/530
+                if readonly_promise: # https://github.com/mido/mido/issues/530
                     yield msg
                 else:
                     yield msg.copy()
@@ -126,4 +126,4 @@ def merge_tracks(tracks):
 
     messages.sort(key=lambda msg: msg.time)
 
-    return MidiTrack(fix_end_of_track(_to_reltime(messages), read_only_promise=False))
+    return MidiTrack(fix_end_of_track(_to_reltime(messages), readonly_promise=False))


### PR DESCRIPTION
The rarely used function `fix_end_of_track()` now has the input argument `readonly_promise`, default `False`. `True` saves memory but yields outputs that should not be modified because their modification would affect the original inputs in weird incoherent ways. `merge_tracks()` uses `readonly_promise=False` because it stores the outputs of `fix_end_of_track()` and thus they might get modified later. `MidiFile.save()` uses `readonly_promise=True` because it discards the outputs of `fix_end_of_track()` without modifying them. Those are deliberate choices and thus even the usage of the default parameter `readonly_promise=False` is explicitly coded.

This should fix issue #530.

Attention: Tests were not run and not adapted.