### PR TITLE
Switch linting to Ruff; fix issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2018 Ole Martin Bjorndalen <ombdalen@gmail.com>
-#
-# SPDX-License-Identifier: CC0-1.0
-
-[flake8]
-ignore = F401, C901, F901
-exclude = .git,__pycache__,docs/conf.py,old,build,dist
-max-complexity = 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,10 @@ jobs:
         run: python3 -m pip install --upgrade pip setuptools wheel
       - name: Install mido in dev mode
         run: python3 -m pip install --quiet .[lint-code]
-      - name: Lint code with flake
-        run: flake8
+      - name: Lint code with ruff
+        run: ruff check .
+        env:
+          RUFF_OUTPUT_FORMAT: github
 
   reuse:
     runs-on: ubuntu-latest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@
 exclude SECURITY.md
 prune docs/_build
 prune logo
-include README.rst LICENSE .readthedocs.yaml .flake8 .reuse/dep5
+include README.rst LICENSE .readthedocs.yaml .reuse/dep5
 include docs/_static/.gitkeep
 recursive-include docs *.bat
 recursive-include docs *.py

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -119,12 +119,12 @@ It's good practice to check your changes *locally* before submitting.
 Linting
 ^^^^^^^
 
-Linting is done with `flake8 <https://flake8.pycqa.org/en/latest/>`_.
-Its configuration can be found in `.flake8`.
+Linting is done with `ruff <https://docs.astral.sh/ruff>`_.
+Its configuration can be found in `pyproject.toml`.
 
 You can lint your code using::
 
-    flake8
+    ruff check .
 
 
 Copyright and REUSE Compliance

--- a/examples/midifiles/create_midi_file.py
+++ b/examples/midifiles/create_midi_file.py
@@ -12,7 +12,7 @@ The file is saved to test.mid.
 import random
 import sys
 
-from mido import Message, MidiFile, MidiTrack, MAX_PITCHWHEEL
+from mido import MAX_PITCHWHEEL, Message, MidiFile, MidiTrack
 
 notes = [64, 64 + 7, 64 + 12]
 

--- a/examples/midifiles/midifile_to_json.py
+++ b/examples/midifiles/midifile_to_json.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-import sys
 import json
+import sys
+
 import mido
 
 

--- a/examples/using_rtmidi_directly.py
+++ b/examples/using_rtmidi_directly.py
@@ -8,8 +8,10 @@ First example from here modified to use Mido messages:
     http://pypi.python.org/pypi/python-rtmidi/
 """
 import time
-import mido
+
 import rtmidi
+
+import mido
 
 midiout = rtmidi.MidiOut()
 available_ports = midiout.get_ports()

--- a/extras/hid_joystick.py
+++ b/extras/hid_joystick.py
@@ -79,7 +79,6 @@ Other axis have values from -32767 to 32767 as well.
 
 """
 import struct
-import select
 
 JS_EVENT_BUTTON = 0x1
 JS_EVENT_AXIS = 0x2
@@ -251,7 +250,6 @@ def play_drums(dev, out):
 
 
 if __name__ == '__main__':
-    import sys
     import mido
 
     with open('/dev/input/js0') as dev:

--- a/mido/__init__.py
+++ b/mido/__init__.py
@@ -92,7 +92,6 @@ Getting started:
     >>> get_input_names()
     ['MPK mini MIDI 1', 'SH-201']
 """
-import os
 
 from . import ports, sockets
 from .backends.backend import Backend
@@ -107,8 +106,34 @@ from .parser import Parser, parse, parse_all
 from .syx import read_syx_file, write_syx_file
 from .version import version_info
 
-# Prevent splat import.
-__all__ = []
+__all__ = [
+    "KeySignatureError",
+    "MAX_PITCHWHEEL",
+    "MAX_SONGPOS",
+    "MIN_PITCHWHEEL",
+    "MIN_SONGPOS",
+    "Message",
+    "MetaMessage",
+    "MidiFile",
+    "MidiTrack",
+    "Parser",
+    "UnknownMetaMessage",
+    "bpm2tempo",
+    "format_as_string",
+    "merge_tracks",
+    "parse",
+    "parse_all",
+    "parse_string",
+    "parse_string_stream",
+    "ports",
+    "read_syx_file",
+    "second2tick",
+    "sockets",
+    "tempo2bpm",
+    "tick2second",
+    "version_info",
+    "write_syx_file",
+]
 
 
 def set_backend(name=None, load=False):
@@ -137,5 +162,3 @@ def set_backend(name=None, load=False):
 
 
 set_backend()
-
-del os

--- a/mido/__init__.py
+++ b/mido/__init__.py
@@ -95,13 +95,28 @@ Getting started:
 
 from . import ports, sockets
 from .backends.backend import Backend
-from .messages import (Message, parse_string, parse_string_stream,
-                       format_as_string, MIN_PITCHWHEEL, MAX_PITCHWHEEL,
-                       MIN_SONGPOS, MAX_SONGPOS)
-from .midifiles import (MidiFile, MidiTrack, merge_tracks,
-                        MetaMessage, UnknownMetaMessage,
-                        bpm2tempo, tempo2bpm, tick2second, second2tick,
-                        KeySignatureError)
+from .messages import (
+    MAX_PITCHWHEEL,
+    MAX_SONGPOS,
+    MIN_PITCHWHEEL,
+    MIN_SONGPOS,
+    Message,
+    format_as_string,
+    parse_string,
+    parse_string_stream,
+)
+from .midifiles import (
+    KeySignatureError,
+    MetaMessage,
+    MidiFile,
+    MidiTrack,
+    UnknownMetaMessage,
+    bpm2tempo,
+    merge_tracks,
+    second2tick,
+    tempo2bpm,
+    tick2second,
+)
 from .parser import Parser, parse, parse_all
 from .syx import read_syx_file, write_syx_file
 from .version import version_info

--- a/mido/backends/_parser_queue.py
+++ b/mido/backends/_parser_queue.py
@@ -2,11 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-from ..parser import Parser
-
+import queue
 from threading import RLock
 
-import queue
+from ..parser import Parser
 
 
 class ParserQueue:

--- a/mido/backends/_parser_queue.py
+++ b/mido/backends/_parser_queue.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import time
-from .. import ports
 from ..parser import Parser
 
 from threading import RLock

--- a/mido/backends/amidi.py
+++ b/mido/backends/amidi.py
@@ -16,10 +16,12 @@ TODO:
 """
 import os
 import select
-import threading
 import subprocess
+import threading
+
 from ..messages import Message
-from ._common import PortMethods, InputMethods, OutputMethods
+from ._common import InputMethods, OutputMethods, PortMethods
+
 """
 Dir Device    Name
 IO  hw:1,0,0  UM-1 MIDI 1

--- a/mido/backends/backend.py
+++ b/mido/backends/backend.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os
 import importlib
+import os
+
 from .. import ports
 
 DEFAULT_BACKEND = 'mido.backends.rtmidi'

--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -13,6 +13,7 @@ http://portmedia.sourceforge.net/portmidi/doxygen/
 """
 import ctypes
 import threading
+
 from ..ports import BaseInput, BaseOutput, sleep
 from . import portmidi_init as pm
 

--- a/mido/backends/portmidi_init.py
+++ b/mido/backends/portmidi_init.py
@@ -8,9 +8,9 @@ Low-level wrapper for PortMidi library
 Copied straight from Grant Yoshida's portmidizero, with slight
 modifications.
 """
-import sys
 import ctypes
 import ctypes.util
+import sys
 
 dll_name = ''
 if sys.platform == 'darwin':

--- a/mido/backends/pygame.py
+++ b/mido/backends/pygame.py
@@ -11,6 +11,7 @@ http://www.pygame.org/docs/ref/midi.html
 """
 
 from pygame import midi
+
 from ..ports import BaseInput, BaseOutput
 
 

--- a/mido/backends/rtmidi.py
+++ b/mido/backends/rtmidi.py
@@ -9,10 +9,11 @@ http://pypi.python.org/pypi/python-rtmidi/
 import threading
 
 import rtmidi
-from ._parser_queue import ParserQueue
-from .rtmidi_utils import expand_alsa_port_name
+
 from .. import ports
 from ..messages import Message
+from ._parser_queue import ParserQueue
+from .rtmidi_utils import expand_alsa_port_name
 
 
 def _get_api_lookup():

--- a/mido/backends/rtmidi_python.py
+++ b/mido/backends/rtmidi_python.py
@@ -24,6 +24,7 @@ TODO:
 import queue
 
 import rtmidi_python as rtmidi
+
 # TODO: change this to a relative import if the backend is included in
 # the package.
 from ..ports import BaseInput, BaseOutput

--- a/mido/messages/__init__.py
+++ b/mido/messages/__init__.py
@@ -7,3 +7,20 @@ from .specs import (SPEC_LOOKUP, SPEC_BY_TYPE, SPEC_BY_STATUS,
                     MIN_PITCHWHEEL, MAX_PITCHWHEEL, MIN_SONGPOS, MAX_SONGPOS)
 from .messages import (BaseMessage, Message, parse_string,
                        format_as_string, parse_string_stream)
+
+
+__all__ = [
+    "BaseMessage",
+    "MAX_PITCHWHEEL",
+    "MAX_SONGPOS",
+    "MIN_PITCHWHEEL",
+    "MIN_SONGPOS",
+    "Message",
+    "SPEC_BY_STATUS",
+    "SPEC_BY_TYPE",
+    "SPEC_LOOKUP",
+    "check_time",
+    "format_as_string",
+    "parse_string",
+    "parse_string_stream",
+]

--- a/mido/messages/__init__.py
+++ b/mido/messages/__init__.py
@@ -3,11 +3,22 @@
 # SPDX-License-Identifier: MIT
 
 from .checks import check_time
-from .specs import (SPEC_LOOKUP, SPEC_BY_TYPE, SPEC_BY_STATUS,
-                    MIN_PITCHWHEEL, MAX_PITCHWHEEL, MIN_SONGPOS, MAX_SONGPOS)
-from .messages import (BaseMessage, Message, parse_string,
-                       format_as_string, parse_string_stream)
-
+from .messages import (
+    BaseMessage,
+    Message,
+    format_as_string,
+    parse_string,
+    parse_string_stream,
+)
+from .specs import (
+    MAX_PITCHWHEEL,
+    MAX_SONGPOS,
+    MIN_PITCHWHEEL,
+    MIN_SONGPOS,
+    SPEC_BY_STATUS,
+    SPEC_BY_TYPE,
+    SPEC_LOOKUP,
+)
 
 __all__ = [
     "BaseMessage",

--- a/mido/messages/checks.py
+++ b/mido/messages/checks.py
@@ -67,8 +67,6 @@ def check_time(time):
 
 
 _CHECKS = {
-    'type': check_type,
-    'data': check_data,
     'channel': check_channel,
     'control': check_data_byte,
     'data': check_data,
@@ -79,9 +77,10 @@ _CHECKS = {
     'pos': check_pos,
     'program': check_data_byte,
     'song': check_data_byte,
+    'time': check_time,
+    'type': check_type,
     'value': check_data_byte,
     'velocity': check_data_byte,
-    'time': check_time,
 }
 
 

--- a/mido/messages/checks.py
+++ b/mido/messages/checks.py
@@ -3,8 +3,14 @@
 # SPDX-License-Identifier: MIT
 
 from numbers import Integral, Real
-from .specs import (SPEC_BY_TYPE, MIN_SONGPOS, MAX_SONGPOS,
-                    MIN_PITCHWHEEL, MAX_PITCHWHEEL)
+
+from .specs import (
+    MAX_PITCHWHEEL,
+    MAX_SONGPOS,
+    MIN_PITCHWHEEL,
+    MIN_SONGPOS,
+    SPEC_BY_TYPE,
+)
 
 
 def check_type(type_):

--- a/mido/messages/decode.py
+++ b/mido/messages/decode.py
@@ -2,10 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .specs import (SYSEX_START, SYSEX_END,
-                    SPEC_BY_STATUS, CHANNEL_MESSAGES,
-                    MIN_PITCHWHEEL)
 from .checks import check_data
+from .specs import (
+    CHANNEL_MESSAGES,
+    MIN_PITCHWHEEL,
+    SPEC_BY_STATUS,
+    SYSEX_END,
+    SYSEX_START,
+)
 
 
 def _decode_sysex_data(data):

--- a/mido/messages/encode.py
+++ b/mido/messages/encode.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .specs import CHANNEL_MESSAGES, SPEC_BY_TYPE, MIN_PITCHWHEEL
+from .specs import CHANNEL_MESSAGES, MIN_PITCHWHEEL, SPEC_BY_TYPE
 
 
 def _encode_pitchwheel(msg):

--- a/mido/messages/messages.py
+++ b/mido/messages/messages.py
@@ -4,10 +4,10 @@
 
 import re
 
-from .checks import check_msgdict, check_value, check_data
+from .checks import check_data, check_msgdict, check_value
 from .decode import decode_message
 from .encode import encode_message
-from .specs import make_msgdict, SPEC_BY_TYPE, REALTIME_TYPES
+from .specs import REALTIME_TYPES, SPEC_BY_TYPE, make_msgdict
 from .strings import msg2str, str2msg
 
 

--- a/mido/midifiles/__init__.py
+++ b/mido/midifiles/__init__.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .meta import MetaMessage, UnknownMetaMessage, KeySignatureError
-from .units import tick2second, second2tick, bpm2tempo, tempo2bpm
-from .tracks import MidiTrack, merge_tracks
+from .meta import KeySignatureError, MetaMessage, UnknownMetaMessage
 from .midifiles import MidiFile
+from .tracks import MidiTrack, merge_tracks
+from .units import bpm2tempo, second2tick, tempo2bpm, tick2second
 
 __all__ = [
     "KeySignatureError",

--- a/mido/midifiles/__init__.py
+++ b/mido/midifiles/__init__.py
@@ -6,3 +6,16 @@ from .meta import MetaMessage, UnknownMetaMessage, KeySignatureError
 from .units import tick2second, second2tick, bpm2tempo, tempo2bpm
 from .tracks import MidiTrack, merge_tracks
 from .midifiles import MidiFile
+
+__all__ = [
+    "KeySignatureError",
+    "MetaMessage",
+    "MidiFile",
+    "MidiTrack",
+    "UnknownMetaMessage",
+    "bpm2tempo",
+    "merge_tracks",
+    "second2tick",
+    "tempo2bpm",
+    "tick2second",
+]

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -19,7 +19,6 @@ http://www.recordingblogs.com/sa/tabid/82/EntryId/44/MIDI-Part-XIII-Delta-time-a
 http://www.sonicspot.com/guide/midifiles.html
 """
 
-import io
 import string
 import struct
 import time

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -24,11 +24,10 @@ import struct
 import time
 from numbers import Integral
 
-from .meta import (MetaMessage, build_meta_message, meta_charset,
-                   encode_variable_int)
-from .tracks import MidiTrack, merge_tracks, fix_end_of_track
+from ..messages import SPEC_BY_STATUS, Message
+from .meta import MetaMessage, build_meta_message, encode_variable_int, meta_charset
+from .tracks import MidiTrack, fix_end_of_track, merge_tracks
 from .units import tick2second
-from ..messages import Message, SPEC_BY_STATUS
 
 # The default tempo is 120 BPM.
 # (500000 microseconds per beat (quarter note).)

--- a/mido/sockets.py
+++ b/mido/sockets.py
@@ -5,10 +5,11 @@
 """
 MIDI over TCP/IP.
 """
-import socket
 import select
+import socket
+
 from .parser import Parser
-from .ports import MultiPort, BaseIOPort
+from .ports import BaseIOPort, MultiPort
 
 
 def _is_readable(socket):

--- a/mido/tokenizer.py
+++ b/mido/tokenizer.py
@@ -4,7 +4,8 @@
 
 from collections import deque
 from numbers import Integral
-from .messages.specs import SYSEX_START, SYSEX_END, SPEC_BY_STATUS
+
+from .messages.specs import SPEC_BY_STATUS, SYSEX_END, SYSEX_START
 
 
 class Tokenizer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,5 +136,6 @@ ignore = [
 extend-select = [
     "E",
     "F",
+    "I",
     "W",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ build-docs = [
     'sphinx-rtd-theme~=1.2.2',
 ]
 check-manifest = ['check-manifest>=0.49',]
-lint-code = ['flake8~=5.0.4',]
+lint-code = ['ruff~=0.1.6',]
 lint-reuse = ['reuse~=1.1.2',]
 ports-pygame = ['PyGame~=2.5',]
 ports-rtmidi = ['python-rtmidi~=1.5.4',]
@@ -126,4 +126,15 @@ norecursedirs = [
     "build",
     "dist",
     "examples",
+]
+
+[tool.ruff]
+ignore = [
+    "F401",  # TODO: Enable
+]
+
+extend-select = [
+    "E",
+    "F",
+    "W",
 ]

--- a/scripts/mido_play.py
+++ b/scripts/mido_play.py
@@ -19,7 +19,7 @@ import argparse
 import sys
 
 import mido
-from mido import MidiFile, Message, tempo2bpm
+from mido import Message, MidiFile, tempo2bpm
 
 
 def parse_args():

--- a/tests/messages/test_checks.py
+++ b/tests/messages/test_checks.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from pytest import raises
+
 from mido.messages.checks import check_time
 
 

--- a/tests/messages/test_decode.py
+++ b/tests/messages/test_decode.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from pytest import raises
+
 from mido.messages.decode import decode_message
 
 

--- a/tests/messages/test_encode.py
+++ b/tests/messages/test_encode.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-from mido.messages.specs import SPEC_BY_STATUS
-from mido.messages.encode import encode_message
 from mido.messages.decode import decode_message
+from mido.messages.encode import encode_message
+from mido.messages.specs import SPEC_BY_STATUS
 
 
 def test_encode_decode_all():

--- a/tests/messages/test_messages.py
+++ b/tests/messages/test_messages.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 from pytest import raises
-from mido.messages.specs import MIN_PITCHWHEEL, MAX_PITCHWHEEL, \
-    MIN_SONGPOS, MAX_SONGPOS
+
 from mido.messages.messages import Message, SysexData
+from mido.messages.specs import MAX_PITCHWHEEL, MAX_SONGPOS, MIN_PITCHWHEEL, MIN_SONGPOS
 
 
 def test_msg_time_equality():

--- a/tests/midifiles/test_meta.py
+++ b/tests/midifiles/test_meta.py
@@ -3,8 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
-from mido.midifiles.meta import MetaMessage, UnknownMetaMessage, \
-    MetaSpec_key_signature, KeySignatureError
+
+from mido.midifiles.meta import (
+    KeySignatureError,
+    MetaMessage,
+    MetaSpec_key_signature,
+    UnknownMetaMessage,
+)
 
 
 def test_copy_invalid_argument():

--- a/tests/midifiles/test_midifiles.py
+++ b/tests/midifiles/test_midifiles.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 import io
+
 from pytest import raises
+
 from mido.messages import Message
+from mido.midifiles.meta import KeySignatureError, MetaMessage
 from mido.midifiles.midifiles import MidiFile, MidiTrack
-from mido.midifiles.meta import MetaMessage, KeySignatureError
 
 HEADER_ONE_TRACK = """
 4d 54 68 64  # MThd

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import itertools
+
 from mido.messages import Message
 from mido.midifiles.meta import MetaMessage
 from mido.midifiles.tracks import MidiTrack

--- a/tests/midifiles/test_units.py
+++ b/tests/midifiles/test_units.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from mido.midifiles.units import tempo2bpm, bpm2tempo, tick2second, second2tick
+from mido.midifiles.units import bpm2tempo, second2tick, tempo2bpm, tick2second
 
 
 def test_tempo2bpm():

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from mido.messages import Message
-from mido.midifiles.meta import MetaMessage, UnknownMetaMessage
+from mido.midifiles.meta import UnknownMetaMessage
 from mido.frozen import (is_frozen, freeze_message, thaw_message,
                          FrozenMessage, FrozenMetaMessage,
                          FrozenUnknownMetaMessage)

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -2,11 +2,16 @@
 #
 # SPDX-License-Identifier: MIT
 
+from mido.frozen import (
+    FrozenMessage,
+    FrozenMetaMessage,
+    FrozenUnknownMetaMessage,
+    freeze_message,
+    is_frozen,
+    thaw_message,
+)
 from mido.messages import Message
 from mido.midifiles.meta import UnknownMetaMessage
-from mido.frozen import (is_frozen, freeze_message, thaw_message,
-                         FrozenMessage, FrozenMetaMessage,
-                         FrozenUnknownMetaMessage)
 
 
 def test_hashability():

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
+
 from mido.messages import Message
 from mido.ports import BaseIOPort
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
+
 from mido.sockets import parse_address
 
 

--- a/tests/test_syx.py
+++ b/tests/test_syx.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from pytest import raises
+
 from mido.messages import Message
 from mido.syx import read_syx_file, write_syx_file
 


### PR DESCRIPTION
This PR switches the linting for the project from flake8 to [ruff](https://beta.ruff.rs/) and fixes some issues uncovered by it.

For instance, the "unused imports" lint had been disabled altogether in the flake8 configuration, presumably because it would complain loudly about the `__init__` re-exports. No more!