### PR TITLE
Enable a bunch more Ruff categories

### DIFF
--- a/examples/backends/rtm.py
+++ b/examples/backends/rtm.py
@@ -74,13 +74,13 @@ class PortCommon:
                 # In RtMidi, the default port is the first port.
                 try:
                     self.name = ports[0]
-                except IndexError:
-                    raise OSError('no ports available')
+                except IndexError as ie:
+                    raise OSError('no ports available') from ie
 
             try:
                 port_id = ports.index(self.name)
-            except ValueError:
-                raise OSError(f'unknown port {self.name!r}')
+            except ValueError as ve:
+                raise OSError(f'unknown port {self.name!r}') from ve
 
             self._rt.open_port(port_id)
 

--- a/mido/backends/amidi.py
+++ b/mido/backends/amidi.py
@@ -14,7 +14,6 @@ TODO:
 * do sysex messages work?
 * starting amidi for every message sent is costly
 """
-import os
 import select
 import subprocess
 import threading
@@ -33,7 +32,10 @@ IO  hw:2,0,0  MPK mini MIDI 1
 def get_devices():
     devices = []
 
-    lines = os.popen('amidi -l').read().splitlines()
+    lines = subprocess.check_output(
+        ["amidi", "-l"],
+        encoding="utf-8",
+    ).splitlines()
     for line in lines[1:]:
         mode, device, name = line.strip().split(None, 2)
 

--- a/mido/backends/portmidi.py
+++ b/mido/backends/portmidi.py
@@ -196,7 +196,7 @@ class Input(PortCommon, BaseInput):
             # (TODO: not sure if this is correct.)
             packed_message = event.message & 0xffffffff
 
-            for i in range(4):
+            for _i in range(4):
                 byte = packed_message & 0xff
                 self._parser.feed_byte(byte)
                 packed_message >>= 8

--- a/mido/backends/rtmidi.py
+++ b/mido/backends/rtmidi.py
@@ -39,8 +39,8 @@ def _get_api_id(name=None):
 
     try:
         api = _name_to_api[name]
-    except KeyError:
-        raise ValueError(f'unknown API {name}')
+    except KeyError as ke:
+        raise ValueError(f'unknown API {name}') from ke
 
     if name in get_api_names():
         return api
@@ -104,7 +104,7 @@ def _open_port(rt, name=None, client_name=None, virtual=False, api=None):
     try:
         rt.open_port(port_id)
     except RuntimeError as err:
-        raise OSError(*err.args)
+        raise OSError(*err.args) from err
 
     return name
 

--- a/mido/backends/rtmidi_python.py
+++ b/mido/backends/rtmidi_python.py
@@ -76,18 +76,18 @@ class PortCommon:
                 # In RtMidi, the default port is the first port.
                 try:
                     self.name = ports[0]
-                except IndexError:
-                    raise OSError('no ports available')
+                except IndexError as ie:
+                    raise OSError('no ports available') from ie
 
             try:
                 port_id = ports.index(self.name)
-            except ValueError:
-                raise OSError(f'unknown port {self.name!r}')
+            except ValueError as ve:
+                raise OSError(f'unknown port {self.name!r}') from ve
 
             try:
                 self._rt.open_port(port_id)
             except RuntimeError as err:
-                raise OSError(*err.args)
+                raise OSError(*err.args) from err
 
         # api = _api_to_name[self._rt.get_current_api()]
         api = ''

--- a/mido/messages/decode.py
+++ b/mido/messages/decode.py
@@ -81,8 +81,8 @@ def decode_message(msg_bytes, time=0, check=True):
 
     try:
         spec = SPEC_BY_STATUS[status_byte]
-    except KeyError:
-        raise ValueError(f'invalid status byte {status_byte!r}')
+    except KeyError as ke:
+        raise ValueError(f'invalid status byte {status_byte!r}') from ke
 
     msg = {
         'type': spec['type'],

--- a/mido/messages/strings.py
+++ b/mido/messages/strings.py
@@ -45,8 +45,8 @@ def _parse_data(value):
 
     try:
         return [int(byte) for byte in value[1:-1].split(',')]
-    except ValueError:
-        raise ValueError('unable to parse data bytes')
+    except ValueError as ve:
+        raise ValueError('unable to parse data bytes') from ve
 
 
 def str2msg(text):

--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -88,14 +88,14 @@ def signed(to_type, n):
 
     try:
         pack_format, unpack_format = formats[to_type]
-    except KeyError:
-        raise ValueError(f'invalid integer type {to_type}')
+    except KeyError as ke:
+        raise ValueError(f'invalid integer type {to_type}') from ke
 
     try:
         packed = struct.pack(pack_format, n)
         return struct.unpack(unpack_format, packed)[0]
     except struct.error as err:
-        raise ValueError(*err.args)
+        raise ValueError(*err.args) from err
 
 
 def unsigned(to_type, n):
@@ -402,14 +402,14 @@ class MetaSpec_key_signature(MetaSpec):
         mode = data[1]
         try:
             message.key = _key_signature_decode[(key, mode)]
-        except KeyError:
+        except KeyError as ke:
             if key < 7:
                 msg = ('Could not decode key with {} '
                        'flats and mode {}'.format(abs(key), mode))
             else:
                 msg = ('Could not decode key with {} '
                        'sharps and mode {}'.format(key, mode))
-            raise KeySignatureError(msg)
+            raise KeySignatureError(msg) from ke
 
     def encode(self, message):
         key, mode = _key_signature_encode[message.key]

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -116,8 +116,8 @@ def read_file_header(infile):
 def read_message(infile, status_byte, peek_data, delta, clip=False):
     try:
         spec = SPEC_BY_STATUS[status_byte]
-    except LookupError:
-        raise OSError(f'undefined status byte 0x{status_byte:02x}')
+    except LookupError as le:
+        raise OSError(f'undefined status byte 0x{status_byte:02x}') from le
 
     # Subtract 1 for status byte.
     size = spec['length'] - 1 - len(peek_data)

--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -43,7 +43,7 @@ def print_byte(byte, pos=0):
     if char.isspace() or char not in string.printable:
         char = '.'
 
-    print(f'  {pos:06x}: {byte:02x}  {char}')
+    print(f'  {pos:06x}: {byte:02x}  {char}')  # noqa: T201
 
 
 class DebugFileWrapper:
@@ -78,7 +78,7 @@ def read_bytes(infile, size):
 
 
 def _dbg(text=''):
-    print(text)
+    print(text)  # noqa: T201
 
 
 # We can't use the chunk module for two reasons:
@@ -480,12 +480,10 @@ class MidiFile:
         print_tracks(meta_only=True) -> will print only MetaMessages
         """
         for i, track in enumerate(self.tracks):
-            print(f'=== Track {i}')
+            print(f'=== Track {i}')  # noqa: T201
             for msg in track:
-                if not isinstance(msg, MetaMessage) and meta_only:
-                    pass
-                else:
-                    print(f'{msg!r}')
+                if isinstance(msg, MetaMessage) or not meta_only:
+                    print(f'{msg!r}')  # noqa: T201
 
     def __repr__(self):
         if self.tracks:

--- a/mido/sockets.py
+++ b/mido/sockets.py
@@ -104,7 +104,7 @@ class SocketPort(BaseIOPort):
             try:
                 byte = self._rfile.read(1)
             except OSError as err:
-                raise OSError(err.args[1])
+                raise OSError(err.args[1]) from err
             if len(byte) == 0:
                 # The other end has disconnected.
                 self.close()
@@ -121,7 +121,7 @@ class SocketPort(BaseIOPort):
                 # Broken pipe. The other end has disconnected.
                 self.close()
 
-            raise OSError(err.args[1])
+            raise OSError(err.args[1]) from err
 
     def _close(self):
         self._socket.close()
@@ -149,8 +149,8 @@ def parse_address(address):
     host, port = words
     try:
         port = int(port)
-    except ValueError:
-        raise ValueError('port number must be an integer')
+    except ValueError as ve:
+        raise ValueError('port number must be an integer') from ve
 
     # Note: port 0 is not allowed.
     if not 0 < port < (2**16):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,15 +140,24 @@ extend-select = [
     "I",
     "S",  # security lints
     "W",
+    "T",
 ]
 
 [tool.ruff.per-file-ignores]
 "tests/**" = [
     "S101",  # allow assertions in tests
 ]
+"extras/**" = [
+    "T201",  # print allowed
+]
+"scripts/**" = [
+    "T201",  # print allowed
+]
+
 "examples/**" = [
     "B007",  # allow slightly sloppy loop variables in examples
     "S311",  # allow RNGs that are not cryptographically secure
+    "T201",  # print allowed
 ]
 "mido/backends/amidi.py" = [
     "S603",  # allow subprocesses with possibly untrusted input

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,5 +137,18 @@ extend-select = [
     "E",
     "F",
     "I",
+    "S",  # security lints
     "W",
+]
+
+[tool.ruff.per-file-ignores]
+"tests/**" = [
+    "S101",  # allow assertions in tests
+]
+"examples/**" = [
+    "S311",  # allow RNGs that are not cryptographically secure
+]
+"mido/backends/amidi.py" = [
+    "S603",  # allow subprocesses with possibly untrusted input
+    "S607",  # allow `amidi` as a partial path
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ ignore = [
 ]
 
 extend-select = [
+    "B",
     "E",
     "F",
     "I",
@@ -146,6 +147,7 @@ extend-select = [
     "S101",  # allow assertions in tests
 ]
 "examples/**" = [
+    "B007",  # allow slightly sloppy loop variables in examples
     "S311",  # allow RNGs that are not cryptographically secure
 ]
 "mido/backends/amidi.py" = [

--- a/tests/messages/test_messages.py
+++ b/tests/messages/test_messages.py
@@ -94,7 +94,7 @@ def test_copy_handles_data_generator():
 
 def test_compare_with_nonmessage():
     with raises(TypeError):
-        Message('clock') == 'not a message'
+        assert Message('clock') == 'not a message'
 
 
 def test_from_dict_default_values():

--- a/tests/messages/test_messages.py
+++ b/tests/messages/test_messages.py
@@ -117,5 +117,5 @@ def test_from_hex_sysex_data_type():
 
 def test_repr():
     msg = Message('note_on', channel=1, note=2, time=3)
-    msg_eval = eval(repr(msg))
+    msg_eval = eval(repr(msg))  # noqa: S307
     assert msg == msg_eval

--- a/tests/midifiles/test_meta.py
+++ b/tests/midifiles/test_meta.py
@@ -44,13 +44,13 @@ class TestKeySignature:
 
 def test_meta_message_repr():
     msg = MetaMessage('end_of_track', time=10)
-    msg_eval = eval(repr(msg))
+    msg_eval = eval(repr(msg))  # noqa: S307
     assert msg == msg_eval
 
 
 def test_unknown_meta_message_repr():
     msg = UnknownMetaMessage(type_byte=99, data=[1, 2], time=10)
-    msg_eval = eval(repr(msg))
+    msg_eval = eval(repr(msg))  # noqa: S307
     assert msg == msg_eval
 
 

--- a/tests/midifiles/test_midifiles.py
+++ b/tests/midifiles/test_midifiles.py
@@ -181,7 +181,7 @@ def test_midifile_repr():
             Message('note_on', channel=2, note=6, time=9),
             Message('note_off', channel=2, note=6, time=9)]),
     ])
-    midifile_eval = eval(repr(midifile))
+    midifile_eval = eval(repr(midifile))  # noqa: S307
     for track, track_eval in zip(midifile.tracks, midifile_eval.tracks):
         for m1, m2 in zip(track, track_eval):
             assert m1 == m2

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -34,7 +34,7 @@ def test_track_repr():
         Message('note_on', channel=1, note=2, time=3),
         Message('note_off', channel=1, note=2, time=3),
     ])
-    track_eval = eval(repr(track))
+    track_eval = eval(repr(track))  # noqa: S307
     for m1, m2 in zip(track, track_eval):
         assert m1 == m2
 

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -41,20 +41,20 @@ def test_is_frozen():
 
 def test_frozen_repr():
     msg = FrozenMessage('note_on', channel=1, note=2, time=3)
-    msg_eval = eval(repr(msg))
+    msg_eval = eval(repr(msg))  # noqa: S307
     assert isinstance(msg_eval, FrozenMessage)
     assert msg == msg_eval
 
 
 def test_frozen_meta_repr():
     msg = FrozenMetaMessage('end_of_track', time=10)
-    msg_eval = eval(repr(msg))
+    msg_eval = eval(repr(msg))  # noqa: S307
     assert isinstance(msg_eval, FrozenMetaMessage)
     assert msg == msg_eval
 
 
 def test_frozen_unknown_meta_repr():
     msg = FrozenUnknownMetaMessage(type_byte=99, data=[1, 2], time=10)
-    msg_eval = eval(repr(msg))
+    msg_eval = eval(repr(msg))  # noqa: S307
     assert isinstance(msg_eval, UnknownMetaMessage)
     assert msg == msg_eval

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -124,7 +124,7 @@ def test_encode_and_parse_all():
     for type_ in sorted(specs.SPEC_BY_TYPE.keys()):
         msg = Message(type_)
         parser.feed(msg.bytes())
-        parser.get_message() == msg
+        assert parser.get_message() == msg
 
     assert parser.get_message() is None
 


### PR DESCRIPTION
Each commit enables a given category and addresses it to some degree.

As for S307 in tests, I'm not sure it makes much sense for `repr`s for messages to be `eval`able (since eval is evil); perhaps that should be changed for 2.0...