### PR TITLE
Update meta messages for skip_checks arg

### DIFF
--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -476,18 +476,19 @@ def build_meta_message(meta_type, data, delta=0):
 class MetaMessage(BaseMessage):
     is_meta = True
 
-    def __init__(self, type, **kwargs):
+    def __init__(self, type, skip_checks=False, **kwargs):
         # TODO: handle unknown type?
 
         spec = _META_SPEC_BY_TYPE[type]
         self_vars = vars(self)
         self_vars['type'] = type
 
-        for name in kwargs:
-            if name not in spec.settable_attributes:
-                raise ValueError(
-                    '{} is not a valid argument for this message type'.format(
-                        name))
+        if not skip_checks:
+            for name in kwargs:
+                if name not in spec.settable_attributes:
+                    raise ValueError(
+                        '{} is not a valid argument for this message type'.format(
+                            name))
 
         for name, value in zip(spec.attributes, spec.defaults):
             self_vars[name] = value
@@ -570,7 +571,7 @@ class MetaMessage(BaseMessage):
 
 
 class UnknownMetaMessage(MetaMessage):
-    def __init__(self, type_byte, data=None, time=0, type='unknown_meta'):
+    def __init__(self, type_byte, data=None, time=0, type='unknown_meta', **kwargs):
         if data is None:
             data = ()
         else:

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -67,4 +67,4 @@ def test_merge_large_midifile():
     max_track_duration_ticks = max(
         sum(msg.time for msg in t) for t in mid.tracks)
     assert merged_duration_ticks == max_track_duration_ticks
-    assert (finish - start) < 2.0
+    assert (finish - start) < 3.0

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -7,7 +7,7 @@ import time
 
 import mido
 from mido.messages import Message
-from mido.midifiles.meta import MetaMessage
+from mido.midifiles.meta import MetaMessage, UnknownMetaMessage
 from mido.midifiles.tracks import MidiTrack
 
 zip = getattr(itertools, 'izip', zip)
@@ -47,6 +47,17 @@ def test_merge_large_midifile():
             t.append(mido.Message("note_on", note=72, time=1000 + 100 * k))
             t.append(mido.Message("note_off", note=72, time=500 + 100 * k))
         mid.tracks.append(t)
+
+    # Add meta messages for testing.
+    meta1 = mido.MetaMessage('track_name', name='Test Track 1')
+    meta2 = mido.MetaMessage('track_name', name='Test Track 2')
+    meta3 = mido.MetaMessage('time_signature', numerator=4, denominator=4, clocks_per_click=24, notated_32nd_notes_per_beat=8)
+    unknown_meta = mido.UnknownMetaMessage(0x50, b'\x01\x02\x03')
+
+    mid.tracks[0].insert(0, meta1)
+    mid.tracks[1].insert(0, meta2)
+    mid.tracks[2].insert(0, meta3)
+    mid.tracks[3].insert(0, unknown_meta)
 
     start = time.time()
     merged = list(mido.merge_tracks(mid.tracks, skip_checks=True))

--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -51,7 +51,11 @@ def test_merge_large_midifile():
     # Add meta messages for testing.
     meta1 = mido.MetaMessage('track_name', name='Test Track 1')
     meta2 = mido.MetaMessage('track_name', name='Test Track 2')
-    meta3 = mido.MetaMessage('time_signature', numerator=4, denominator=4, clocks_per_click=24, notated_32nd_notes_per_beat=8)
+    meta3 = mido.MetaMessage('time_signature',
+                             numerator=4,
+                             denominator=4,
+                             clocks_per_click=24,
+                             notated_32nd_notes_per_beat=8)
     unknown_meta = mido.UnknownMetaMessage(0x50, b'\x01\x02\x03')
 
     mid.tracks[0].insert(0, meta1)


### PR DESCRIPTION
Quick fix to address #570 

I missed this message in the initial implementation of `skip_checks`. Sorry. Let's make sure we cover all our cases this time.

```
➜  mido git:(main) ✗ grep -R "class.*Message" mido
Binary file mido/messages/__pycache__/messages.cpython-310.pyc matches
mido/messages/messages.py:class BaseMessage:
mido/messages/messages.py:class Message(BaseMessage):
mido/frozen.py:class FrozenMessage(Frozen, Message):
mido/frozen.py:class FrozenMetaMessage(Frozen, MetaMessage):
mido/frozen.py:class FrozenUnknownMetaMessage(Frozen, UnknownMetaMessage):
mido/frozen.py:        class_ = FrozenMessage
mido/frozen.py:        class_ = FrozenUnknownMetaMessage
mido/frozen.py:        class_ = FrozenMetaMessage
mido/frozen.py:        class_ = Message
mido/frozen.py:        class_ = UnknownMetaMessage
mido/frozen.py:        class_ = MetaMessage
mido/midifiles/meta.py:class MetaMessage(BaseMessage):
mido/midifiles/meta.py:class UnknownMetaMessage(MetaMessage):
```

There is no logic in `BaseMessage` to handle. `Message` is done. `Frozen*` have no logic either. `MetaMessage` is addressed in this commit. `UnknownMetaMessage` doesn't seem to need it but I've added a `**kwargs` to the initializer to avoid:
```
TypeError: UnknownMetaMessage.__init__() got an unexpected keyword argument 'skip_checks'
```