### PR TITLE
Remove upper bound of `packaging`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 
 dependencies = [
     "importlib_metadata; python_version<'3.8'",  # For version introspection
-    "packaging~=23.1",  # To provide a nice version_info opbject
+    "packaging>=23.1",  # To provide a nice version_info opbject
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
`packaging` is now 24.0 so perhaps the upper version bound should be removed.