### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-github-pages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is no longer available in ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is no longer available in ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,12 +106,20 @@ jobs:
             - '3.11'
             - '3.12'
             - '3.13'
-        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
+        exclude:
+          # Python < v3.8 does not support Apple Silicon ARM64.
           - python-version: "3.7"
             os: macOS-latest
-        include: # So run those legacy versions on Intel CPUs.
+          # Python 3.7 has been removed from the latest Ubuntu images.
+          - python-version: "3.7"
+            os: ubuntu-latest
+        include:
+          # Run legacy versions on Intel CPUs.
           - python-version: "3.7"
             os: macOS-13
+          # Use the latest Ubuntu which still has Python 3.7
+          - python-version: "3.7"
+            os: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   style:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is no longer available in ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
           RUFF_OUTPUT_FORMAT: github
 
   reuse:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is no longer available in ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
         run: reuse lint
 
   manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is no longer available in ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
         run: check-manifest --verbose
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Python 3.7 is no longer available in ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.7 has been removed from ubuntu-latest image.