### PR TITLE
Increase time limit for test_tracks

### DIFF
--- a/tests/midifiles/test_tracks.py
+++ b/tests/midifiles/test_tracks.py
@@ -71,4 +71,4 @@ def test_merge_large_midifile():
     max_track_duration_ticks = max(
         sum(msg.time for msg in t) for t in mid.tracks)
     assert merged_duration_ticks == max_track_duration_ticks
-    assert (finish - start) < 3.0
+    assert (finish - start) < 5.0


### PR DESCRIPTION
On SiFive Unmatched, a RISC-V board, it takes ~4.5s to finish the task.

```text
>       assert (finish - start) < 3.0
E       assert (1757619359.8915396 - 1757619355.55446) < 3.0

tests/midifiles/test_tracks.py:74: AssertionError
======================== 1 failed, 121 passed in 10.23s ========================
```