### PR TITLE
Remove extra comma in docs calling `from_hex`

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -188,7 +188,7 @@ You can also create a message from ``bytes`` using class methods:
 .. code-block:: python
 
    msg1 = mido.Message.from_bytes([0x90, 0x40, 0x60])
-   msg2 = mido.Message.from_hex('90, 40 60')
+   msg2 = mido.Message.from_hex('90 40 60')
 
 The ``bytes`` must contain exactly one complete message. If not
 ``ValueError`` is raised.

--- a/docs/messages/index.rst
+++ b/docs/messages/index.rst
@@ -97,7 +97,7 @@ You can also create a message from ``bytes`` using class methods:
 .. code-block:: python
 
    msg1 = mido.Message.from_bytes([0x90, 0x40, 0x60])
-   msg2 = mido.Message.from_hex('90, 40 60')
+   msg2 = mido.Message.from_hex('90 40 60')
 
 The ``bytes`` must contain exactly one complete message. If not
 ``ValueError`` is raised.


### PR DESCRIPTION
The `from_hex` code examples result in an error since they contain a comma so this PR removes them.