### PR TITLE
Add test coverage automation and reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,3 +134,37 @@ jobs:
         run: python3 -m pip install --quiet .[test-code]
       - name: Test with pytest
         run: pytest
+
+  coverage:
+    needs:
+      - docs
+      - manifest
+      - reuse
+      - style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+      - name: Upgrade pip
+        run: python3 -m pip install --upgrade pip setuptools wheel
+      - name: Install mido in dev mode
+        run: python3 -m pip install --quiet .[test-coverage]
+      - name: Run coverage with pytest suite
+        run: coverage run -m pytest
+      - name: Run coverage report (terminal)
+        run: coverage report -m
+      - name: Run coverage XML report
+        run: coverage xml
+      - name: Run coverage HTML report
+        run: coverage html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__
 mido/_version.py
 # Documentation built by Sphinx
 docs/_build
+# Coverage output
+coverage.xml
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,12 +70,14 @@ ports-rtmidi = ['python-rtmidi~=1.5.4',]
 ports-rtmidi-python = ['rtmidi-python~=0.2.2',]
 release = ['twine~=4.0.2',]
 test-code = ['pytest~=7.4.0',]
+test-coverage = ['coverage~=7.13.5']
 
 # Convenience groups for human interaction
 dev = [
     'mido[check-manifest]',
     'mido[lint-code]',
     'mido[test-code]',
+    'mido[test-coverage]',
     'mido[lint-reuse]',
     'mido[build-docs]',
     'mido[release]',
@@ -129,6 +131,13 @@ norecursedirs = [
     "dist",
     "examples",
 ]
+
+[tool.coverage.run]
+source = ["mido"]
+branch = false
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ruff]
 ignore = [


### PR DESCRIPTION
Implements coverage automation as discussed in #557.

## Changes

- New `test-coverage` dependency group (coverage 7.13.x)
- Coverage configuration in `pyproject.toml` (line coverage, source = mido)
- New `coverage` CI job on ubuntu-latest + Python 3.12
- Terminal, XML, and HTML reports; HTML uploaded as workflow artifact
- `.gitignore` entries for coverage outputs

## Local testing

Tested locally with coverage 7.13.5 on Python 3.12.8:
- `coverage run -m pytest` — passes
- `coverage report` — 46% baseline, as expected
- `coverage xml` / `coverage html` — artifacts generated correctly

## Scope

Scope validated with @rdoursenaud in #557. Follow-ups intentionally deferred:
- Multi-OS coverage with per-backend restrictions

Refs #557