### PR TITLE
Remove confusing filename attribute from MidiFile

### DIFF
--- a/mido/midifiles/midifiles.py
+++ b/mido/midifiles/midifiles.py
@@ -297,7 +297,6 @@ class MidiFile:
                  tracks=None
                  ):
 
-        self.filename = filename
         self.type = type
         self.ticks_per_beat = ticks_per_beat
         self.charset = charset
@@ -315,7 +314,7 @@ class MidiFile:
             self.tracks = tracks
         elif file is not None:
             self._load(file)
-        elif self.filename is not None:
+        elif filename is not None:
             with open(filename, 'rb') as file:
                 self._load(file)
 

--- a/mido/scripts/mido_play.py
+++ b/mido/scripts/mido_play.py
@@ -52,7 +52,7 @@ def parse_args():
 def play_file(output, filename, print_messages):
     midi_file = MidiFile(filename)
 
-    print(f'Playing {midi_file.filename}.')
+    print(f'Playing {filename}.')
     length = midi_file.length
     print('Song length: {} minutes, {} seconds.'.format(
         int(length / 60),


### PR DESCRIPTION
Removing the confusing `filename` attribute as discussed in #589 

Note that this might break the API for some users but since the filename is always given by the user, it is very simple to fix in their code

The second file that I edited (`mido_play.py`) is a good example of such a quick fix