### PR TITLE
Don't crash on a meta message shorter than its spec expects

### DIFF
--- a/mido/midifiles/meta.py
+++ b/mido/midifiles/meta.py
@@ -467,8 +467,15 @@ def build_meta_message(meta_type, data, delta=0):
     else:
         msg = MetaMessage(spec.type, time=delta)
 
-        # This adds attributes to msg:
-        spec.decode(msg, data)
+        try:
+            # This adds attributes to msg:
+            spec.decode(msg, data)
+        except IndexError:
+            # A meta message whose data is shorter than its spec expects (e.g.
+            # a truncated time_signature) would otherwise raise a bare
+            # IndexError while reading the file. Keep the raw bytes as an
+            # unknown meta message instead of crashing.
+            return UnknownMetaMessage(meta_type, data, time=delta)
 
         return msg
 

--- a/tests/midifiles/test_meta.py
+++ b/tests/midifiles/test_meta.py
@@ -9,6 +9,7 @@ from mido.midifiles.meta import (
     MetaMessage,
     MetaSpec_key_signature,
     UnknownMetaMessage,
+    build_meta_message,
 )
 
 
@@ -83,6 +84,17 @@ def test_meta_from_bytes_data_too_long():
     ]
     with pytest.raises(ValueError):
         MetaMessage.from_bytes(test_bytes)
+
+
+def test_build_meta_message_data_too_short():
+    # A known meta type whose data is shorter than its spec expects (here a
+    # time_signature, 0x58, which needs four bytes) used to raise a bare
+    # IndexError while reading a file. The raw bytes should be preserved as an
+    # unknown meta message instead.
+    msg = build_meta_message(0x58, [4])
+    assert isinstance(msg, UnknownMetaMessage)
+    assert msg.type_byte == 0x58
+    assert msg.data == (4,)
 
 
 def test_meta_from_bytes_text():


### PR DESCRIPTION
Reading a MIDI file with a truncated meta message raises a bare `IndexError` instead of being handled:

```python
import io, mido
# a track containing a time_signature meta (0xFF 0x58) with length 1 instead of 4
data = (b'MThd\x00\x00\x00\x06\x00\x00\x00\x01\x01\xe0'
        b'MTrk\x00\x00\x00\x09\x00\xff\x58\x01\x04\x00\xff\x2f\x00')
mido.MidiFile(file=io.BytesIO(data))
# IndexError: list index out of range
```

Most `MetaSpec.decode()` methods read fixed offsets (`data[0]`..`data[3]`) without checking the length, so any meta message whose declared length is shorter than its spec needs (time_signature, key_signature, smpte_offset, set_tempo, sequence_number, ...) trips an `IndexError`. I wrapped the `spec.decode()` call in `build_meta_message` so a too-short message falls back to `UnknownMetaMessage` with the raw bytes preserved (round-trippable), matching how an unknown meta *type* is already handled. Valid messages are unaffected.

Added a test in test_meta.py; it raises IndexError on `main` and passes with the change, and the rest of the meta tests still pass. Found it by fuzzing `MidiFile` with mutated files.