### PR TITLE
Derive REALTIME_TYPES from the 0xF8-0xFF status byte range

### DIFF
--- a/mido/messages/specs.py
+++ b/mido/messages/specs.py
@@ -93,7 +93,10 @@ def _make_spec_lookups(
 
 SPEC_LOOKUP, SPEC_BY_STATUS, SPEC_BY_TYPE = _make_spec_lookups(SPECS)
 
-REALTIME_TYPES = {'tune_request', 'clock', 'start', 'continue', 'stop'}
+# System real time is exactly the status byte range 0xf8..0xff, so derive the
+# names rather than repeating them.
+REALTIME_TYPES = {spec.type for spec in SPECS
+                  if spec.status_byte in REALTIME_MESSAGES}
 
 DEFAULT_VALUES = {
     'channel': 0,

--- a/tests/messages/test_messages.py
+++ b/tests/messages/test_messages.py
@@ -119,3 +119,13 @@ def test_repr():
     msg = Message('note_on', channel=1, note=2, time=3)
     msg_eval = eval(repr(msg))  # noqa: S307
     assert msg == msg_eval
+
+
+def test_is_realtime():
+    # MIDI 1.0 Detailed Specification, Table I: System Real Time is 0xF8..0xFF.
+    # tune_request (0xF6) is System Common.
+    realtime = {'clock', 'start', 'continue', 'stop', 'active_sensing', 'reset'}
+    for type_ in ['clock', 'start', 'continue', 'stop', 'active_sensing',
+                  'reset', 'tune_request', 'quarter_frame', 'songpos',
+                  'song_select', 'sysex', 'note_on']:
+        assert Message(type_).is_realtime == (type_ in realtime), type_

--- a/tests/midifiles/test_midifiles.py
+++ b/tests/midifiles/test_midifiles.py
@@ -185,3 +185,25 @@ def test_midifile_repr():
     for track, track_eval in zip(midifile.tracks, midifile_eval.tracks):
         for m1, m2 in zip(track, track_eval):
             assert m1 == m2
+
+
+def test_realtime_message_in_track():
+    # 0xFE and 0xFF are System Real Time, and inside an MTrk chunk 0xFF is
+    # the meta event prefix, so writing one produces an unreadable file.
+    for type_ in ['clock', 'start', 'continue', 'stop', 'active_sensing',
+                  'reset']:
+        mid = MidiFile()
+        mid.tracks.append(MidiTrack([Message(type_)]))
+        with raises(ValueError):
+            mid.save(file=io.BytesIO())
+
+
+def test_system_common_message_in_track():
+    # tune_request is System Common, not System Real Time, and is written
+    # like the other System Common messages the writer already accepts.
+    mid = MidiFile()
+    mid.tracks.append(MidiTrack([Message('tune_request')]))
+    outfile = io.BytesIO()
+    mid.save(file=outfile)
+    outfile.seek(0)
+    assert MidiFile(file=outfile).tracks[0][0] == Message('tune_request')


### PR DESCRIPTION
`REALTIME_TYPES` (`mido/messages/specs.py:96`) is wrong in both directions. System Real Time is exactly `0xF8..0xFF` (MIDI 1.0 Detailed Specification, Table I: Summary of Status Bytes). The set lists `tune_request`, which is `0xF6` and System Common, and omits `active_sensing` (`0xFE`) and `reset` (`0xFF`) — both of which sit under this file's own `# System real time messages` comment, 30 lines above.

`Message.is_realtime` reads that set, and `write_track` (`mido/midifiles/midifiles.py:248`) uses it as the gate on what may go into a track. So on current `main`:

```
>>> mid.tracks.append(MidiTrack([Message('note_on'), Message('reset')]))
>>> mid.save(file=buf)          # no complaint
>>> MidiFile(file=buf)          # EOFError
```

Trailing bytes are `00 90 3c 40 00 ff 00 80 3c 40 00 ff 2f 00` — the `ff` is read as the meta event prefix (SMF 1.0: inside an MTrk chunk `FF` introduces a meta event), the reader takes `00` as the type and eats the rest as length and payload. `active_sensing` writes a bare `fe` that round-trips inside mido but is not a legal MTrk event. `tune_request` is refused, though `write_track` already accepts `quarter_frame`, `songpos` and `song_select`, the other System Common messages.

The set is derivable from two things already in the same file, so this derives it instead of restating it.

Behaviour change worth naming: saving `active_sensing` or `reset` in a track now raises `ValueError` instead of writing a broken file, and `tune_request` is now accepted. `docs/about_midi.rst:64` already lists `reset` as System Real Time.

Measurement: `pytest` 126 -> 129, same venv both legs. `ruff check .` at the pinned `ruff~=0.1.6` exits 0 — my local ruff 0.16 reports 94 pre-existing findings, which is a version difference, not this change. `reuse lint` compliant, 131/131.

Mutants, each verified in the file before running: (A) restore the shipped literal — 3 fail; (B) add `active_sensing` and `reset` but keep `tune_request` — 2 fail, so the tests pin the `0xF6` classification too; (C) drop `tune_request` without adding the other two — 2 fail. The new tests hardcode the six names from the spec rather than deriving them, or they would be tautological against the new definition.

Not tested: no port backend, so I did not check whether any backend relies on `is_realtime` for `tune_request` — `grep -rn is_realtime` finds only `write_track`, but the backends are unexercised here. No real hardware.

Written with AI assistance (Claude).
